### PR TITLE
Remove trailing comma in `Diff.cabal`

### DIFF
--- a/Diff.cabal
+++ b/Diff.cabal
@@ -37,7 +37,7 @@ library
     , pretty >= 1.1
   hs-source-dirs:  src
   exposed-modules:
-                   Data.Algorithm.Diff,
+                   Data.Algorithm.Diff
                    Data.Algorithm.DiffOutput
                    Data.Algorithm.DiffContext
   ghc-options:     -Wall -funbox-strict-fields


### PR DESCRIPTION
With this change, [MicroCabal](https://github.com/augustss/MicroCabal/) (a build tool for [MicroHs](https://github.com/augustss/MicroHs)) can build this package. Newer cabal versions also require the comma usage to be consistent.