### PR TITLE
Remove `groupBy'` for specialized internal `splitBothBoth` helper

### DIFF
--- a/src/Data/Algorithm/DiffContext.hs
+++ b/src/Data/Algorithm/DiffContext.hs
@@ -18,7 +18,6 @@ module Data.Algorithm.DiffContext
     , getContextDiffNumbered
     , Numbered(Numbered), numbered, unnumber
     , unNumberContextDiff
-    , groupBy'
     ) where
 
 import Data.Algorithm.Diff (PolyDiff(..), Diff, getGroupedDiff)
@@ -35,30 +34,14 @@ type ContextDiff c = [Hunk c]
 -- on 'Diff' constructors.
 type Hunk c = [Diff [c]]
 
-
--- | Groups elements so that consecutive elements in a group satisfy the predicate.
--- This is unlike 'Data.List.groupBy' where grouped elements are only guaranteed to
--- satisfy the predicate w.r.t. the first element of the group.
---
--- For instance, to split the input where there are two consecutive `1`s:
---
---     > let notBoth1 a b = not (a == 1 && b == 1) in
---     >
---     > groupBy' notBoth1 [1,1,2,3,1,1,4,5,6,1]
---     > [[1],[1,2,3,1],[1,4,5,6,1]]
---     >
---     > groupBy notBoth1 [1,1,2,3,1,1,4,5,6,1]
---     > [[1],[1,2,3],[1],[1,4,5,6],[1]]
---
--- In the first result the list is split anywhere there are two
--- adjacent ones, as desired.
-groupBy' :: (a -> a -> Bool) -> [a] -> [[a]]
-groupBy' _ [] = []
-groupBy' eq (x0 : xs0) = go [x0] xs0
-    where
-      go (x : xs) (y : zs) | eq x y = go (y : x : xs) zs
-      go g (y : zs) = reverse g : go [y] zs
-      go g [] = [reverse g]
+-- | Split a 'Diff' list at consecutive 'Both'-'Both' boundaries.
+splitBothBoth :: [Diff [c]] -> [Hunk c]
+splitBothBoth = go []
+  where
+    go :: Hunk c -> [Diff [c]] -> [Hunk c]
+    go g (x@Both{} : y@Both{} : xs) = reverse (x:g) : go [] (y:xs)
+    go g (x : xs) = go (x:g) xs
+    go g [] = [reverse g]
 
 data Numbered a = Numbered Int a deriving Show
 instance Eq a => Eq (Numbered a) where
@@ -122,10 +105,8 @@ getContextDiffNumbered contextSize a0 b0 =
     -- text in the middle. Note that a non-trivial partition can only happen after
     -- the matching text has been reduced to become consecutive 'Both' values
     -- corresponding to a hunk's suffix and the following hunk prefix.
-    groupBy' (\a b -> not (isBoth a && isBoth b)) $ doPrefix $ getGroupedDiff a0 b0
+    splitBothBoth $ doPrefix $ getGroupedDiff a0 b0
     where
-      isBoth (Both _ _) = True
-      isBoth _ = False
       -- | Handle the common text leading up to a diff.
       --
       -- Postcondition: The @a@ elements in @doPrefix h@ are a subset of those in @h@,


### PR DESCRIPTION
The `groupBy'` helper is defined within the `Data.Algorithm.DiffContext` module with the purpose of creating separate hunks within the `getContextDiffNumbered` function. 

In this PR, this helper is specialized to `Hunk c` instead of arbitrary lists with one variation: the equality predicate argument is removed by (essentially) inlining the predicate used at the call site: `\a b -> not (isBoth a && isBoth b)`. As a consequence, the required split is done throughout the recursive accumulation and consing, and the `isBoth` local helper is removed from `getContextDiffNumbered`.

This change merges two helpers and reduces the amount of indirection, making the operation in question easier to reason about and the body of `getContextDiffNumbered` more transparent and concise:

```haskell
    splitBothBoth $ doPrefix $ getGroupedDiff a0 b0
```

NOTE: This change passes all `cabal test`s and results in no perceptible performance variation on `cabal bench` (from #25).

NOTE: The `groupBy'` export is now removed and not replaced by the new function (reason being that the new helper is an implementation detail), thus probably requiring a version bump. The script at the bottom of this description reveals that no module directly importing `DiffContext` calls `groupBy'`. It might still be the case for a module re-export to hide a call from this script, but this seems very unlikely. A Github search for `groupBy' language:Haskell` shows bespoke definitions of `groupBy'` are very common. Besides, this is far from being a loss given that focused alternatives to `Prelude.groupBy` with equivalent behavior to `DiffContext.groupBy'` (but perhaps, better performance) exist in the ecosystem:
 
 - https://hackage.haskell.org/package/groupBy
 - https://hackage.haskell.org/package/utility-ht-0.0.17.2/docs/Data-List-HT.html#v:groupBy
 
 ```bash
 #!/usr/bin/env bash
# Check whether any Diff library direct dependency calls Data.Algorithm.DiffContext.groupBy'
# which would be broken by removing its export.
# Requires: curl, cabal, grep.

set -euo pipefail

WORKDIR=$(mktemp -d)
trap 'rm -rf "$WORKDIR"' EXIT

echo "Fetching reverse dependencies of Diff from Hackage..."
curl -sf 'https://hackage.haskell.org/package/Diff/reverse' \
  | grep -oP 'href="/package/\K[^/"]+' \
  | sed 's/-[0-9][0-9.]*$//' \
  | sort -u \
  > "$WORKDIR/revdeps.txt"

echo "Updating Hackage index..."
cabal update -v0

echo "Downloading sources..."
mkdir -p "$WORKDIR/sources"
while read -r pkg; do
  cabal get "$pkg" --destdir="$WORKDIR/sources" -v0 2>/dev/null \
    || echo "  Warning: could not fetch $pkg"
done < "$WORKDIR/revdeps.txt"

echo "Searching for groupBy' references..."

# Pass 1: find all files that import Data.Algorithm.DiffContext in any form.
IMPORTING_FILES=$(grep -rl "import.*Data\.Algorithm\.DiffContext" \
  "$WORKDIR/sources" --include="*.hs")

if [[ -z "$IMPORTING_FILES" ]]; then
  echo "No files import Data.Algorithm.DiffContext — safe to remove the export."
  exit 0
fi

echo "Files importing Data.Algorithm.DiffContext:"
echo "$IMPORTING_FILES" | sed "s|$WORKDIR/sources/||"
echo

# Pass 2: within those files, search for any use of groupBy'.
echo "$IMPORTING_FILES" | xargs grep -n "groupBy'" \
  && echo "Matches found above." \
  || echo "No matches — safe to remove the export."
 ```