### PR TITLE
Add static checks via Liquid Haskell annotations

### DIFF
--- a/.github/workflows/liquidhaskell.yml
+++ b/.github/workflows/liquidhaskell.yml
@@ -1,0 +1,55 @@
+name: LiquidHaskell
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  liquidhaskell:
+    name: Build / Run Checks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cabal: ["3.16.0.0"]
+        ghc:
+          - "9.14.1"
+        z3:
+          - "4.15.1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup z3-${{ matrix.z3 }}
+        uses: pavpanchekha/setup-z3@6b2d476d7a9227e0d8d2b94f73cd9fcba91b5e98
+        with:
+          version: ${{ matrix.z3 }}
+          distribution: glibc-2.39
+
+      - name: Setup GHC and cabal-install
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+
+      - name: Configure cabal
+        working-directory: ./Diff-liquidhaskell
+        run: |
+          cabal update
+          # should produce a plan.json file
+          cabal build --dry-run
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            ./Diff-liquidhaskell/dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-${{ hashFiles('./Diff-liquidhaskell/dist-newstyle/cache/plan.json') }}
+
+      - name: Install dependencies
+        working-directory: ./Diff-liquidhaskell
+        run: cabal build --dependencies-only -j Diff-liquidhaskell
+
+      - name: Build (run LiquidHaskell checks)
+        working-directory: ./Diff-liquidhaskell
+        run: cabal build -j Diff-liquidhaskell

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/dist-newstyle/
+dist-newstyle/
+cabal.project.local

--- a/Diff-liquidhaskell/Diff-liquidhaskell.cabal
+++ b/Diff-liquidhaskell/Diff-liquidhaskell.cabal
@@ -26,6 +26,9 @@ library
       base          >= 4.22.0.0 && < 5
     , array
     , pretty        >= 1.1
+      -- LH version scheme: 0.<GHC_VERSION>.<LH_REVISION>
+      -- Update the corresponding versions in .github/workflows/liquidhaskell.yml
+      -- after upgrading GHC and LH to keep CI in sync.
     , liquidhaskell ^>= 0.9.14.1.1
   -- Recompilation check is disabled to make sure changes to specification
   -- annotations are checked by the LH plugin (otherwise they are silently ignored

--- a/Diff-liquidhaskell/Diff-liquidhaskell.cabal
+++ b/Diff-liquidhaskell/Diff-liquidhaskell.cabal
@@ -1,0 +1,34 @@
+cabal-version: 2.4
+name:          Diff-liquidhaskell
+version:       0.1.0.0
+synopsis:      Liquid Haskell static checks for the Diff package
+description:
+  Provides a test suite whose build executes Diff's Liquid Haskell refinement type
+  annotation checks.
+  Exists as a separate package to break the cyclic dependency:
+  Diff -> liquidhaskell -> liquidhaskell-boot -> Diff.
+license:       BSD-3-Clause
+build-type:    Simple
+
+tested-with:   GHC == 9.14.1
+
+library
+  default-language: Haskell2010
+  -- Re-use the main Diff source tree so Liquid Haskell checks the real code.
+  hs-source-dirs:   ../src
+  -- No modules are exposed because this package is intended
+  -- for checking the build only.
+  other-modules:
+    Data.Algorithm.Diff
+    Data.Algorithm.DiffOutput
+    Data.Algorithm.DiffContext
+  build-depends:
+      base          >= 4.22.0.0 && < 5
+    , array
+    , pretty        >= 1.1
+    , liquidhaskell ^>= 0.9.14.1.1
+  -- Recompilation check is disabled to make sure changes to specification
+  -- annotations are checked by the LH plugin (otherwise they are silently ignored
+  -- if no source change is introduced).
+  -- All warnings are disabled to focus on LH output.
+  ghc-options: -fplugin=LiquidHaskell -O0 -fforce-recomp -w

--- a/Diff.cabal
+++ b/Diff.cabal
@@ -13,6 +13,7 @@ license-file:        LICENSE
 author:              Sterling Clover
 maintainer:          David Fox <dsf@seereason.com>
 Build-Type:          Simple
+extra-doc-files:     README.md
 
 tested-with:
   GHC == 9.14.1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+## Diff
+
+This is an implementation of the standard diff algorithm in Haskell.
+
+Time complexity is O(ND) (input length * number of differences). Space complexity is O(D^2). Includes utilities for pretty printing.
+
+### Building & testing
+
+Build with
+
+```shell
+cabal build
+```
+
+Test with
+
+```shell
+cabal test
+```
+
+Benchmark with
+
+```shell
+cabal bench
+```
+
+### Checking Diff with Liquid Haskell
+
+The Diff source code can we checked with [Liquid Haskell](https://ucsd-progsys.github.io/liquidhaskell/).
+
+Liquid Haskell requires `ghc` version 9.14.1, and an SMT solver. We have tested
+the checks with the [Z3](https://github.com/Z3Prover/z3) SMT solver (versions 4.16,
+and 4.15.1).
+
+```
+cd Diff-liquidhaskell && cabal build
+```
+
+The `Diff-liquidhaskell` package is a device to avoid the circular dependency between
+`liquidhaskell` and the `Diff` package.
+
+``` mermaid
+flowchart LR
+    Diff --> liquidhaskell --> liquidhaskell-boot --> Diff
+```
+
+Contributions that update the Liquid Haskell checks are appreciated but not required at this point.

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -232,6 +232,7 @@ dstep cd (dl:dls) = addsnake cd (hStep dl) : stepAndMerge dl dls
 -- @(poi dl, poj dl)@, this function advances both 'poi' and 'poj' as long
 -- as consecutive elements match, leaving 'path' unchanged (diagonal moves
 -- are not recorded as edit steps).
+{-@ addsnake :: (Nat -> Nat -> Bool) -> x : DL -> {v : DL | path v == path x } @-}
 addsnake :: (Int -> Int -> Bool) -> DL -> DL
 addsnake cd dl
     | cd pi pj = addsnake cd $

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -125,6 +125,13 @@ type Diff a = PolyDiff a a
 -- Each wave front consists of one 'DL' per /k-diagonal/.  A 'DL' stores the
 -- endpoint coordinates and the edit trace of a \( D \)-path, i.e. a path from the
 -- origin \( (0,0) \) that uses exactly \( D \) non-diagonal edges.
+{-@
+data DL = DL
+    { poi  :: Nat
+    , poj  :: Nat
+    , path :: { p : [DI] | len p <= poi + poj }
+    }
+@-}
 data DL = DL
     { poi  :: !Int   -- ^ /Position On I/ — the @x@-coordinate of the endpoint
                      --   in the edit graph, i.e. the number of elements
@@ -193,6 +200,12 @@ canDiag eq as bs lena lenb = \ i j ->
 -- two members of each pair straddle the same diagonal from opposite sides.
 --
 -- Precondition: The node list must be non-empty.
+{-@
+dstep
+  :: (Nat -> Nat -> Bool)
+  -> {nodes : [DL] | len nodes > 0}
+  -> {v : [DL] | len v = len nodes + 1}
+@-}
 dstep
   :: (Int -> Int -> Bool) -- ^ Diagonal predicate
   -> [DL]                 -- ^ A non-empty wave front of nodes at edit distance D

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -210,6 +210,7 @@ dstep cd (dl:dls) = addsnake cd (hStep dl) : stepAndMerge dl dls
     stepAndMerge prev (next:rest) =
       addsnake cd (furthestReaching (vStep prev) (hStep next)) : stepAndMerge next rest
 
+{-@ lazy addsnake @-}
 -- | Follow a /snake/ from the current position of a 'DL' node.
 --
 -- A snake is a sequence of diagonal (cost-free) edges in the edit graph,
@@ -225,6 +226,7 @@ addsnake cd dl
     | otherwise   = dl
     where pi = poi dl; pj = poj dl
 
+{-@ ignore ses @-}
 -- | Compute shortest edit script (SES), as the minimum sequence of 'DI' edit
 -- steps that transforms @as@ into @bs@, returned in reverse order.
 --

--- a/src/Data/Algorithm/DiffContext.hs
+++ b/src/Data/Algorithm/DiffContext.hs
@@ -38,6 +38,7 @@ type Hunk c = [Diff [c]]
 splitBothBoth :: [Diff [c]] -> [Hunk c]
 splitBothBoth = go []
   where
+    {-@ go :: Hunk c -> xs : [Diff [c]] -> [Hunk c] / [len xs] @-}
     go :: Hunk c -> [Diff [c]] -> [Hunk c]
     go g (x@Both{} : y@Both{} : xs) = reverse (x:g) : go [] (y:xs)
     go g (x : xs) = go (x:g) xs
@@ -118,7 +119,8 @@ getContextDiffNumbered (Just contextSize) a0 b0 =
       -- be split into two other 'Both' diffs. This happens when their contents
       -- are too large compared with the contex size, resulting in some @a@
       -- elements being dropped.
-      doPrefix :: Hunk a -> Hunk a
+      {-@ doPrefix :: h : Hunk c -> [Diff [c]] / [len h, 0]@-}
+      doPrefix :: Hunk c -> [Diff [c]]
       doPrefix [] = []
       -- Trailing common elements are no prefix.
       -- This case corresponds to when both input lists are identical, so the
@@ -129,12 +131,14 @@ getContextDiffNumbered (Just contextSize) a0 b0 =
         Both (drop (length xs - contextSize) xs)
              (drop (length ys - contextSize) ys) : doSuffix more
       -- Prefix finished, do the diff then the following suffix.
-      doPrefix (d : ds) = doSuffix (d : ds)
+      doPrefix (d : ds) = d : doSuffix ds
+
       -- | Handle the common text following a diff.
       --
       -- Precondition: The input does not start with a 'Both' diff. Otherwise,
       -- it behaves like @doPrefix@.
-      doSuffix :: Hunk a -> Hunk a
+      {-@ doSuffix :: h : Hunk c -> [Diff [c]] / [len h, 1] @-}
+      doSuffix :: Hunk c -> [Diff [c]]
       doSuffix [] = []
       -- A trailing suffix.
       doSuffix [Both xs ys] = [Both (take contextSize xs) (take contextSize ys)]

--- a/src/Data/Algorithm/DiffOutput.hs
+++ b/src/Data/Algorithm/DiffOutput.hs
@@ -25,6 +25,7 @@ diffToLineRanges = toLineRange 1 1
           -- | In @toLineRange x y ds@, @x@ is the index of the current string in the
           -- left input of the diff @ds@, and @y@ is the index of the corresponding
           -- string in the right input of the diff @ds@.
+          {-@ toLineRange :: Int -> Int -> diffs : [Diff[String]] -> [DiffOperation LineRange] / [len diffs, 0] @-}
           toLineRange :: Int -> Int -> [Diff [String]] -> [DiffOperation LineRange]
           toLineRange _ _ []=[]
           -- If the lines are the same, we just move forward.
@@ -47,6 +48,7 @@ diffToLineRanges = toLineRange 1 1
                     diff=Deletion (LineRange (leftLine,leftLine+linesF-1) lsF) (rightLine-1)
                 in  diff: toLineRange(leftLine+linesF) rightLine rs
           -- | Build 'Change's from adjacent additions and deletions.
+          {-@ toChange :: Int -> Int -> [String] -> [String] -> diffs : [Diff [String]] -> [DiffOperation LineRange] / [len diffs, 1] @-}
           toChange :: Int -- ^ Current left line number.
                    -> Int -- ^ Current right line number.
                    -> [String] -- ^ Lines from the 'First' list (corresponding to deletions).
@@ -102,6 +104,7 @@ parsePrettyDiffs = reverse . doParse [] . lines
   where
     -- | Parsing entry point that iteratively accumulates 'DiffOperation's
     -- until the input is exhausted.
+    {-@ doParse :: [DiffOperation LineRange] -> diffs : [String] -> [DiffOperation LineRange] / [len diffs] @-}
     doParse :: [DiffOperation LineRange] -> [String] -> [DiffOperation LineRange]
     -- NOTE: Incorrectly formatted lines are ignored.
     doParse acc [] = acc


### PR DESCRIPTION
This PR adds static checks using [Liquid Haskell](https://ucsd-progsys.github.io/liquidhaskell/) (LH). The PR does not modify the existing functions, except for one small change with no semantic effect, explained below.

The Liquid Haskell annotations are ignored in regular builds of Diff, but they can be checked by building a new package `Diff-liquidhaskell` that re-uses the source tree of the original `Diff` package, so that the actual code of `Diff` is checked. Usually, using a cabal flag is possible to enable Liquid Haskell instead of creating a separate package, but here that would create a circular dependency since `Diff` is a transitive dependency of `liquidhaskell`. 

Liquid Haskell checks the Haskell modules by using an external SMT solver, which needs to be installed separately. A README is provided with a note about it.

The `Diff-liquidhaskell` build is run on pull requests by the provided CI job.

The static checks were developed during a Tweag's project, described in this [blog post](https://www.tweag.io/blog/2026-06-11-diff-package-static-checks/); the main goal being to strenghten the codebase with static checks of previously informal invariants and expectations. The post explains the full scope of the project, a fraction of which is contributed in this PR, with other PRs to follow if desired.
 
In the following sections ([statically cheked invariants](#statically-checked-invariants), [termination metrics](#termination-metrics) and [omitted checks](#omitted-checks)) I explain the meaning of the LH annotations contained in this PR. The last section addresses some possible concerns from the maintenance perspective.

## Statically checked invariants

The `DL` data type has the following specification:

```haskell
{-@
data DL = DL
    { poi  :: Nat
    , poj  :: Nat
    , path :: { p : [DI] | len p <= poi + poj }
    }
@-}
```
This checks that `DL` coordinate values are always natural numbers (LH defines `Nat` as `Int` values that are `>= 0`), and that their edit trace lenght is bounded by their sum. This specification is in accordance with the algorithm definition and an invariant of the implementation that is expected from any `DL` value. 

The `dstep` function has this specification:

```haskell
{-@
dstep
  :: (Nat -> Nat -> Bool)
  -> {nodes : [DL] | len nodes > 0}
  -> {v : [DL] | len v = len nodes + 1}
@-}
```

Which requires its function argument (the parameterized version of `canDiag`, a.k.a. the diagonal predicate) to only have natural number arguments (pre-condition), the node list argument to be non-empty (pre-condition) and the resulting node list to increase the input length by one (post-condition). Note how we bind the `nodes` variable to the input value and `v` to the output so that we can relate them in the post-condition. This specification provides a detail on the shape of the result, which relates directly to the original algorithm inner loop. 

The last provided specification is

```haskell
{-@ addsnake :: (Nat -> Nat -> Bool) -> x : DL -> {v : DL | path v == path x } @-}
```

Which again requires the function argument (the diagonal predicate) to have only natural number arguments and specifies that input and output nodes *must* have the same edit trace, which is the fundamental requirement for `addsnake` to do what it ought.

The pre- and post-conditions forming the function specifidcations are checked at each call of this functions (unless instructed otherwise).
 
## Termination metrics

Termination metrics are introduced using the  ` / [metric1, metric2,...]` syntax at the end of a function specification. 
They point LH to a reducing quantity across recursive calls in a recursive function definition, which it uses to prove that such function terminates. Sometimes `metric1` decreases, but when it stays constant, then `metric2` should decrease, and so on to define a lexicographic order.

All the introduced metrics are appended to specifications matching the existing function signatures, so no additional checks have been introduced:

```haskell
{-@ go :: Hunk c -> xs : [Diff [c]] -> [Hunk c] / [len xs] @-}

{-@ toLineRange :: Int -> Int -> diffs : [Diff[String]] -> [DiffOperation LineRange] / [len diffs, 0] @-}

{-@ toChange :: Int -> Int -> [String] -> [String] -> diffs : [Diff [String]] -> [DiffOperation LineRange] / [len diffs, 1] @-}

{-@ doParse :: [DiffOperation LineRange] -> diffs : [String] -> [DiffOperation LineRange] / [len diffs] @-}
```

The relevant example among these are the mutually recursive `doPreffix` and `doSuffix`:

```haskell
 {-@ doPrefix :: h : Hunk c -> [Diff [c]] / [len h, 0]@-}
 {-@ doSuffix :: h : Hunk c -> [Diff [c]] / [len h, 1] @-}
```

Which uses the fact that, in most equations, the (mutually) recursive call is performed on the tail of the list, so the list length is reduced. The second metric (just constants) is a fallback for the case of `doSuffix` second guard of its third equation where `doPreffix` is called on a list of equal length as the input; in this case the second metric decreases from 1 to 0.

The only source change in this PR is a small refactoring introduced for this termination check to work:

```diff
-      doPrefix (d : ds) = doSuffix (d : ds)
+      doPrefix (d : ds) = d : doSuffix ds
```

This does not change the semantics, because when we reach this equation `d` is known to not be a `Both` value and this takes us to the last `doSuffix` equation that does the same thing.

## Omitted checks

The following annotations

```haskell
{-@ lazy addsnake @-} 

{-@ ignore ses @-} 
```

Prevent LH from trying to prove termination for `addsnake` and omit all checks inside `ses` definition body. This is so because both are significantly more complex to check and are left for another PR.


## Other changes

- The `README` file explains how to build and test Diff, and how to run Liquid Haskell.
- The `.gitignore` file was updated to also ignore nested build outputs.

## Notes on maintenance

Here are some arguments that support the integration of these static checks:

- This addition is **easy to ignore**: even if the LH specifications go unmaintained and break, the library can be build as usual. The LH specification annotations are, to plain GHC, just additional documentation comments.
- For the same reason as above, we have **easy exit**: the static checks can be easily removed by just deleting the annotations (and helper functions) and removing the `Diff-liquidhaskell`.
- In many cases LH specifications **mirror the existing documentation**, so people get extra confidence that those are correct.
- The static checks build up to a clearer connection between the implementation and the original algorithm specification (in the specific case of the `Diff` module), which could **help identify deviations from the expected space-time complexity and possible optimizations**.
- This approach **doesn't need potential contributors to learn new syntax/concepts**: they can go about their Haskell code and don't bother with the formal syntax.
- On the other hand, maintainers gets **extra confidence** of any change or contribution that passes the LH checks.
- The additional layer of assurance could give this implementation **an edge for production use** (speculative).

A question that might naturally arise is: What is a maintainer supposed to make of a failing LH check whose errors she doesn't understand? e.g. an error turns out to be uninformative. In relation to the previous points, these checks can't break the package build and the corresponding CI job failure can be safely ignored.

On the other hand, if the decision is not to ignore the check failures, the failing check readily signals that either the changes violate a specification or introduce new ambiguity that LH cannot solve from existing specifications. The latter case might arise e.g. from a new function definition using other annotated functions or lacking a termination metric if it's recursive; this can be solved simply by adding a `lazy` or `ignore` annotation to the offending function. Cases of the former kind can be trickier to diagnose and fix, but are probably worth a detailed look, e.g. the refactoring of a annotated function might be violating a property we care about. Alternatively the changes could be making a specification obsolete, so removing it altogether is a way forward if writing a new one is not viable given effort constraints.

Both Haskell and Liquid Haskell are technologies we endorse at Tweag, so we have vested interest in their improvement and adoption, and are generally available to help with whatever problem comes up. We are currently working on improving error messages, documentation and developer experience. Helping maintain these annotations and fix surfacing bugs align with our current agenda.