### PR TITLE
Add `Hunk` invariant static checks

### DIFF
--- a/Diff-liquidhaskell/Diff-liquidhaskell.cabal
+++ b/Diff-liquidhaskell/Diff-liquidhaskell.cabal
@@ -20,6 +20,7 @@ library
   -- for checking the build only.
   other-modules:
     Data.Algorithm.Diff
+    Data.Algorithm.Diff.Refinement
     Data.Algorithm.Diff.Type
     Data.Algorithm.DiffOutput
     Data.Algorithm.DiffContext

--- a/Diff-liquidhaskell/Diff-liquidhaskell.cabal
+++ b/Diff-liquidhaskell/Diff-liquidhaskell.cabal
@@ -20,6 +20,7 @@ library
   -- for checking the build only.
   other-modules:
     Data.Algorithm.Diff
+    Data.Algorithm.Diff.Type
     Data.Algorithm.DiffOutput
     Data.Algorithm.DiffContext
   build-depends:

--- a/Diff.cabal
+++ b/Diff.cabal
@@ -42,6 +42,7 @@ library
                    Data.Algorithm.Diff
                    Data.Algorithm.DiffOutput
                    Data.Algorithm.DiffContext
+  other-modules:   Data.Algorithm.Diff.Type
   ghc-options:     -Wall -funbox-strict-fields
 
 source-repository head

--- a/Diff.cabal
+++ b/Diff.cabal
@@ -42,7 +42,8 @@ library
                    Data.Algorithm.Diff
                    Data.Algorithm.DiffOutput
                    Data.Algorithm.DiffContext
-  other-modules:   Data.Algorithm.Diff.Type
+  other-modules:   Data.Algorithm.Diff.Refinement
+                   Data.Algorithm.Diff.Type
   ghc-options:     -Wall -funbox-strict-fields
 
 source-repository head

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -1,4 +1,8 @@
 {-@ LIQUID "--ple" @-}
+-- Import of the 'Data.Algorithm.Diff.Refinement' module is required for LiquidHaskell
+-- specifications in this module, but is unused in the actual code.
+-- The following GHC option suppresses the unused import warning.
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Algorithm.Diff
@@ -72,6 +76,8 @@ module Data.Algorithm.Diff
 import Prelude hiding (pi)
 import Data.Array (listArray, (!))
 import Data.Algorithm.Diff.Type
+import Data.Algorithm.Diff.Refinement (fst3, snd3, thd3, headIsFirst,
+                                        headIsSecond, headIsBoth, noStuttering)
 
 -- | /Diff Instruction/ — an internal enum recording the direction of a single
 -- non-diagonal edge traversed in the Myers edit graph. Every non-diagonal
@@ -305,6 +311,8 @@ getDiff = getDiffBy (==)
 --
 -- > > getGroupedDiff "abcde" "acdf"
 -- > [Both "a" "a",First "b",Both "cd" "cd",First "e",Second "f"]
+{-@ getGroupedDiff :: Eq a => [a] -> [a]
+                           -> {v:[GroupedDiff a a] | noStuttering v} @-}
 getGroupedDiff :: (Eq a) => [a] -> [a] -> [Diff [a]]
 getGroupedDiff = getGroupedDiffBy (==)
 
@@ -324,20 +332,59 @@ getDiffBy eq a b = markup a b . reverse $ ses eq a b
 --
 -- Postcondition: the output list is guaranteed to be /chunked/. i.e. no two adjacent
 -- elements share the same constructor.
+{-@ getGroupedDiffBy :: (a -> b -> Bool) -> [a] -> [b]
+                     -> {vs : [GroupedDiff a b] | noStuttering vs} @-}
 getGroupedDiffBy :: (a -> b -> Bool) -> [a] -> [b] -> [PolyDiff [a] [b]]
-getGroupedDiffBy eq a b = go $ getDiffBy eq a b
-    where go (First x  : xs) = let (fs, rest) = goFirsts  xs in First  (x:fs)     : go rest
-          go (Second x : xs) = let (fs, rest) = goSeconds xs in Second (x:fs)     : go rest
-          go (Both x y : xs) = let (fs, rest) = goBoth    xs
-                                   (fxs, fys) = unzip fs
-                               in Both (x:fxs) (y:fys) : go rest
-          go [] = []
+getGroupedDiffBy eq a b = groupDiff $ getDiffBy eq a b
+  where
+    {-@ groupDiff :: xs : [PolyDiff a b]
+                  -> {vs : [GroupedDiff a b] | noStuttering vs
+                      // The following predicates allow LiquidHaskell keep track
+                      // of the head constructor in each recursive call.
+                      && (headIsFirst xs  <=> headIsFirst vs)
+                      && (headIsSecond xs <=> headIsSecond vs)
+                      && (headIsBoth xs   <=> headIsBoth vs)} @-}
+    groupDiff :: [PolyDiff a b] -> [PolyDiff [a] [b]]
+    groupDiff (First x  : xs) = let (fs, rest) = leadingFirsts  xs
+                                 in First (x:fs) : groupDiff rest
+    groupDiff (Second x : xs) = let (sc, rest) = leadingSeconds xs
+                                 in Second (x:sc) : groupDiff rest
+    groupDiff (Both x y : xs) = let (bxs, bys, rest) = leadingBoths xs
+                                 in Both (x:bxs) (y:bys) : groupDiff rest
+    groupDiff [] = []
 
-          goFirsts  (First x  : xs) = let (fs, rest) = goFirsts  xs in (x:fs, rest)
-          goFirsts  xs = ([],xs)
+    {-@ leadingFirsts :: xs : [PolyDiff a b]
+                      -> {v : ([a], [PolyDiff a b])
+                            | not (headIsFirst (snd v))
+                           // Here, and in the analogous helpers,
+                           // the length comparison is needed for termination check.
+                           && len (snd v) <= len xs
+                           && (headIsSecond xs => headIsSecond (snd v))
+                           && (headIsBoth xs   => headIsBoth (snd v))} @-}
+    leadingFirsts :: [PolyDiff a b] -> ([a], [PolyDiff a b])
+    leadingFirsts (First y : diffs) = let (firsts, rest) = leadingFirsts diffs
+                                       in (y:firsts, rest)
+    leadingFirsts diffs = ([],diffs)
 
-          goSeconds (Second x : xs) = let (fs, rest) = goSeconds xs in (x:fs, rest)
-          goSeconds xs = ([],xs)
+    {-@ leadingSeconds :: xs : [PolyDiff a b]
+                       -> {v : ([b], [PolyDiff a b])
+                             | not (headIsSecond (snd v))
+                            && len (snd v) <= len xs
+                            && (headIsFirst xs => headIsFirst (snd v))
+                            && (headIsBoth xs  => headIsBoth (snd v))} @-}
+    leadingSeconds :: [PolyDiff a b] -> ([b], [PolyDiff a b])
+    leadingSeconds (Second y : diffs) = let (seconds, rest) = leadingSeconds diffs
+                                         in (y:seconds, rest)
+    leadingSeconds diffs = ([],diffs)
 
-          goBoth    (Both x y : xs) = let (fs, rest) = goBoth xs    in ((x,y):fs, rest)
-          goBoth    xs = ([],xs)
+    {-@ leadingBoths :: xs : [PolyDiff a b]
+                     -> {v : ([a], [b], [PolyDiff a b])
+                           | not (headIsBoth (thd3 v))
+                          && len (thd3 v) <= len xs
+                          && (headIsFirst xs  => headIsFirst (thd3 v))
+                          && (headIsSecond xs => headIsSecond (thd3 v))
+                          && len (fst3 v) == len (snd3 v)} @-}
+    leadingBoths :: [PolyDiff a b] -> ([a], [b], [PolyDiff a b])
+    leadingBoths (Both w z : diffs) = let (as, bs, rest) = leadingBoths diffs
+                                       in (w:as, z:bs, rest)
+    leadingBoths diffs = ([], [], diffs)

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -71,7 +71,7 @@ module Data.Algorithm.Diff
 
 import Prelude hiding (pi)
 import Data.Array (listArray, (!))
-import Data.Bifunctor
+import Data.Algorithm.Diff.Type
 
 -- | /Diff Instruction/ — an internal enum recording the direction of a single
 -- non-diagonal edge traversed in the Myers edit graph. Every non-diagonal
@@ -91,34 +91,6 @@ import Data.Bifunctor
 -- recorded as 'DI' steps; they are followed implicitly by 'addsnake' and
 -- produce 'Both' entries in the final output.
 data DI = F | S deriving (Show, Eq)
-
--- | A value tagged with which of two input sequences it came from.
--- The type parameters @a@ and @b@ may differ, which is useful when comparing
--- sequences of different element types via a custom equality predicate.
---
--- Each constructor corresponds to one outcome for a position in the aligned
--- sequences:
---
--- * 'First' — the element exists only in the /first/ input (a deletion).
--- * 'Second' — the element exists only in the /second/ input (an insertion).
--- * 'Both' — the element is common to both inputs.
---   Both the left and right values are retained so that the original
---   elements can be recovered even when equality ignores some fields.
-data PolyDiff a b = First a | Second b | Both a b
-    deriving (Show, Eq)
-
-instance Functor (PolyDiff a) where
-  fmap _ (First a) = First a
-  fmap g (Second b) = Second (g b)
-  fmap g (Both a b) = Both a (g b)
-
-instance Bifunctor PolyDiff where
-  bimap f _ (First a) = First (f a)
-  bimap _ g (Second b) = Second (g b)
-  bimap f g (Both a b) = Both (f a) (g b)
-
--- | This is 'PolyDiff' specialized so both sides are the same type.
-type Diff a = PolyDiff a a
 
 -- | /D-path Location/ — a node on the wave front of the Myers O(ND) diff
 -- algorithm.

--- a/src/Data/Algorithm/Diff/Refinement.hs
+++ b/src/Data/Algorithm/Diff/Refinement.hs
@@ -1,0 +1,84 @@
+-- | Refinement type aliases for 'PolyDiff', related predicates and (lifted) utility functions.
+-- The contents of this module are intended for use in Liquid Haskell specifications;
+-- importing this module can result in unused import warnings in GHC,
+-- which can be suppressed with @-Wno-unused-imports@.
+module Data.Algorithm.Diff.Refinement where
+
+import Data.Algorithm.Diff.Type
+
+-- * Diff predicates and refinement type aliases
+
+{-@
+inline validListDiff
+define length x = len x
+@-}
+-- | True when, for a 'Both' value, both sides have the same length.
+-- 'First' and 'Second' trivially satisfy this.
+validListDiff :: PolyDiff [a] [b] -> Bool
+validListDiff (Both xs ys) = length xs == length ys
+validListDiff (First _) = True
+validListDiff (Second _) = True
+
+{-@ inline nonEmptyDiff @-}
+-- | True when the diff is not empty on either side.
+nonEmptyDiff :: PolyDiff [a] [b] -> Bool
+nonEmptyDiff (First []) = False
+nonEmptyDiff (Second []) = False
+nonEmptyDiff (Both [] _) = False
+nonEmptyDiff (Both _ []) = False
+nonEmptyDiff _ = True
+
+-- A valid list diff is such that any `Both` value has arguments of equal length.
+{-@ type ValidListDiff a b = { d : PolyDiff [a] [b] | validListDiff d }@-}
+
+-- Non-empty valued valid list diffs, used for grouped diffs.
+{-@ type GroupedDiff a b = { d : ValidListDiff a b | nonEmptyDiff d } @-}
+
+{-@ reflect headIsFirst @-}
+{-@ reflect headIsSecond @-}
+{-@ reflect headIsBoth @-}
+-- | Head-constructor predicates for 'PolyDiff' lists.
+-- Reflected (not measures) to avoid sort errors: measures on @[PolyDiff a b]@
+-- would be attached to the polymorphic @[]@ constructor, clashing with
+-- lists of other element types.
+headIsFirst, headIsSecond, headIsBoth :: [PolyDiff a b] -> Bool
+headIsFirst (First _ : _) = True
+headIsFirst _ = False
+headIsSecond (Second _ : _) = True
+headIsSecond _ = False
+headIsBoth (Both _ _ : _) = True
+headIsBoth _ = False
+
+{-@ reflect noStuttering @-}
+-- | True if the list does not contain adjacent 'Diff's of the same type.
+-- Uses head-constructor measures so PLE can work with opaque tails.
+noStuttering :: [PolyDiff a b] -> Bool
+noStuttering [] = True
+noStuttering (First _ : xs) = not (headIsFirst xs) && noStuttering xs
+noStuttering (Second _ : xs) = not (headIsSecond xs) && noStuttering xs
+noStuttering (Both _ _ : xs) = not (headIsBoth xs) && noStuttering xs
+
+{-@ reflect noFFSS @-}
+-- | Like 'noStuttering' but allows Both-Both adjacencies.
+-- This is the invariant preserved by @doPrefix@\/@doSuffix@ which may split
+-- a single 'Both' into two consecutive 'Both' elements.
+noFFSS :: [PolyDiff a b] -> Bool
+noFFSS [] = True
+noFFSS (First _ : xs) = not (headIsFirst xs) && noFFSS xs
+noFFSS (Second _ : xs) = not (headIsSecond xs) && noFFSS xs
+noFFSS (Both _ _ : xs) = noFFSS xs
+
+-- * Lifted utility functions
+
+-- | Measures for triplet projections.
+{-@
+measure fst3
+measure snd3
+measure thd3
+@-}
+fst3 :: (a, b, c) -> a
+fst3 (x, _, _) = x
+snd3 :: (a, b, c) -> b
+snd3 (_, y, _) = y
+thd3 :: (a, b, c) -> c
+thd3 (_, _, z) = z

--- a/src/Data/Algorithm/Diff/Type.hs
+++ b/src/Data/Algorithm/Diff/Type.hs
@@ -1,0 +1,33 @@
+-- | Basic diff type and instances.
+module Data.Algorithm.Diff.Type where
+
+import Data.Bifunctor
+
+-- | A value tagged with which of two input sequences it came from.
+-- The type parameters @a@ and @b@ may differ, which is useful when comparing
+-- sequences of different element types via a custom equality predicate.
+--
+-- Each constructor corresponds to one outcome for a position in the aligned
+-- sequences:
+--
+-- * 'First' — the element exists only in the /first/ input (a deletion).
+-- * 'Second' — the element exists only in the /second/ input (an insertion).
+-- * 'Both' — the element is common to both inputs.
+--   Both the left and right values are retained so that the original
+--   elements can be recovered even when equality ignores some fields.
+{-@ data PolyDiff a b = First a | Second b | Both a b @-}
+data PolyDiff a b = First a | Second b | Both a b
+    deriving (Show, Eq)
+
+instance Functor (PolyDiff a) where
+  fmap _ (First a) = First a
+  fmap g (Second b) = Second (g b)
+  fmap g (Both a b) = Both a (g b)
+
+instance Bifunctor PolyDiff where
+  bimap f _ (First a) = First (f a)
+  bimap _ g (Second b) = Second (g b)
+  bimap f g (Both a b) = Both (f a) (g b)
+
+-- | This is 'PolyDiff' specialized so both sides are the same type.
+type Diff a = PolyDiff a a

--- a/src/Data/Algorithm/DiffContext.hs
+++ b/src/Data/Algorithm/DiffContext.hs
@@ -44,6 +44,9 @@ splitBothBoth = go []
     go g (x : xs) = go (x:g) xs
     go g [] = [reverse g]
 
+{-@ type ContextSize = Nat @-}
+type ContextSize = Int
+
 data Numbered a = Numbered Int a deriving Show
 instance Eq a => Eq (Numbered a) where
   Numbered _ a == Numbered _ b = a == b
@@ -75,7 +78,7 @@ unnumber (Numbered _ a) = a
 -- > -k
 getContextDiff ::
   Eq a
-  => Maybe Int -- ^ Context size. 'Nothing' means returning a whole-diff 'Hunk'.
+  => Maybe ContextSize -- ^ Context size. 'Nothing' means returning a whole-diff 'Hunk'.
   -> [a]
   -> [a]
   -> ContextDiff (Numbered a)
@@ -96,7 +99,7 @@ unNumberContextDiff = fmap (fmap (bimap (fmap unnumber) (fmap unnumber)))
 -- a single hunk with the whole diff is produced.
 getContextDiffNumbered ::
   Eq a
-  => Maybe Int -- ^ Context size. 'Nothing' means returning a whole-diff 'Hunk'.
+  => Maybe ContextSize -- ^ Context size. 'Nothing' means returning a whole-diff 'Hunk'.
   -> [Numbered a]
   -> [Numbered a]
   -> ContextDiff (Numbered a)

--- a/src/Data/Algorithm/DiffContext.hs
+++ b/src/Data/Algorithm/DiffContext.hs
@@ -1,3 +1,9 @@
+{-@ LIQUID "--ple" @-}
+{-@ LIQUID "--ple-with-undecided-guards" @-}
+-- Import of the 'Data.Algorithm.Diff.Refinement' module is required for the
+-- LiquidHaskell specifications in this module, but is unused in the actual code.
+-- The following GHC option suppresses the unused import warning.
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Algorithm.DiffContext
@@ -21,12 +27,15 @@ module Data.Algorithm.DiffContext
     ) where
 
 import Data.Algorithm.Diff (PolyDiff(..), Diff, getGroupedDiff)
+import Data.Algorithm.Diff.Refinement (noStuttering, noFFSS, headIsFirst, headIsSecond)
 import Data.Bifunctor
 import Text.PrettyPrint (Doc, text, empty, hcat)
 
+{-@ type ContextDiff c = [Hunk c] @-}
 -- | A diff consisting of disjoint 'Hunk's.
 type ContextDiff c = [Hunk c]
 
+{-@ type Hunk c = { h : [ValidListDiff c c] | noStuttering h} @-}
 -- | A 'Hunk' is a list of adjacent 'Diff's.
 --
 -- No two consecutive elements in a 'Hunk' are both applications
@@ -35,17 +44,40 @@ type ContextDiff c = [Hunk c]
 type Hunk c = [Diff [c]]
 
 -- | Split a 'Diff' list at consecutive 'Both'-'Both' boundaries.
+{-@ splitBothBoth :: {ds : [ValidListDiff c c] | noFFSS ds} -> [Hunk c] @-}
 splitBothBoth :: [Diff [c]] -> [Hunk c]
 splitBothBoth = go []
   where
-    {-@ go :: Hunk c -> xs : [Diff [c]] -> [Hunk c] / [len xs] @-}
+    {-@ go
+          :: g:Hunk c
+          -> {xs : [ValidListDiff c c] | noFFSS xs && not (headAlike g xs) }
+          -> [Hunk c] / [len xs]
+      @-}
     go :: Hunk c -> [Diff [c]] -> [Hunk c]
     go g (x@Both{} : y@Both{} : xs) = reverse (x:g) : go [] (y:xs)
+      where
+        lemma = lemmaReverseStuttering (x:g)
     go g (x : xs) = go (x:g) xs
     go g [] = [reverse g]
+      where
+        lemma = lemmaReverseStuttering g
 
 {-@ type ContextSize = Nat @-}
 type ContextSize = Int
+
+{-@ opaque-reflect reverse @-}
+
+{-@ assume lemmaReverseStuttering
+      :: xs:_ -> { noStuttering (reverse xs) = noStuttering xs } @-}
+lemmaReverseStuttering :: Hunk c -> ()
+lemmaReverseStuttering _ = ()
+
+{-@ reflect headAlike  @-}
+headAlike :: Hunk c -> Hunk c -> Bool
+headAlike (Both{} : _) (Both{} : _) = True
+headAlike (First{} : _) (First{} : _) = True
+headAlike (Second{} : _) (Second{} : _) = True
+headAlike _ _ = False
 
 data Numbered a = Numbered Int a deriving Show
 instance Eq a => Eq (Numbered a) where
@@ -76,6 +108,14 @@ unnumber (Numbered _ a) = a
 -- >  i
 -- >  j
 -- > -k
+{-@
+getContextDiff ::
+  Eq a
+  => Maybe ContextSize
+  -> [a]
+  -> [a]
+  -> ContextDiff (Numbered a)
+@-}
 getContextDiff ::
   Eq a
   => Maybe ContextSize -- ^ Context size. 'Nothing' means returning a whole-diff 'Hunk'.
@@ -87,6 +127,7 @@ getContextDiff contextSize a b =
 
 -- | If for some reason you need the line numbers stripped from the
 -- result of 'getContextDiff' for backwards compatibility.
+{-@ unNumberContextDiff :: ContextDiff (Numbered a) -> [[Diff [a]]] @-}
 unNumberContextDiff :: ContextDiff (Numbered a) -> ContextDiff a
 unNumberContextDiff = fmap (fmap (bimap (fmap unnumber) (fmap unnumber)))
 
@@ -97,6 +138,14 @@ unNumberContextDiff = fmap (fmap (bimap (fmap unnumber) (fmap unnumber)))
 -- two hunks are merged when the number of common elements between them does not
 -- exceed twice the context size. Furthermore, if @contextSize@ is 'Nothing'
 -- a single hunk with the whole diff is produced.
+{-@
+getContextDiffNumbered ::
+  Eq a
+  => Maybe ContextSize
+  -> [Numbered a]
+  -> [Numbered a]
+  -> ContextDiff (Numbered a)
+@-}
 getContextDiffNumbered ::
   Eq a
   => Maybe ContextSize -- ^ Context size. 'Nothing' means returning a whole-diff 'Hunk'.
@@ -122,7 +171,10 @@ getContextDiffNumbered (Just contextSize) a0 b0 =
       -- be split into two other 'Both' diffs. This happens when their contents
       -- are too large compared with the contex size, resulting in some @a@
       -- elements being dropped.
-      {-@ doPrefix :: h : Hunk c -> [Diff [c]] / [len h, 0]@-}
+      {-@ doPrefix ::  h : Hunk c
+                   -> {v : [ValidListDiff c c] | noFFSS v
+                       && (headIsFirst h <=> headIsFirst v)
+                       && (headIsSecond h <=> headIsSecond v)} / [len h, 0] @-}
       doPrefix :: Hunk c -> [Diff [c]]
       doPrefix [] = []
       -- Trailing common elements are no prefix.
@@ -140,7 +192,10 @@ getContextDiffNumbered (Just contextSize) a0 b0 =
       --
       -- Precondition: The input does not start with a 'Both' diff. Otherwise,
       -- it behaves like @doPrefix@.
-      {-@ doSuffix :: h : Hunk c -> [Diff [c]] / [len h, 1] @-}
+      {-@ doSuffix ::  h : Hunk c
+                   -> {v : [ValidListDiff c c] | noFFSS v
+                       && (headIsFirst h <=> headIsFirst v)
+                       && (headIsSecond h <=> headIsSecond v)} / [len h, 1] @-}
       doSuffix :: Hunk c -> [Diff [c]]
       doSuffix [] = []
       -- A trailing suffix.


### PR DESCRIPTION
This PR introduces Liquid Haskell static checks for the `ContextSize` to be a natural number and for the documented `type Hunk c = [Diff [c]]` invariant: 

> -- No two consecutive elements in a 'Hunk' are both applications
> -- of 'First', 'Second', or 'Both', i.e. the list does not stutter
> -- on 'Diff' constructors.

**Without introducing any semantic change.**

The `Hunk` invariant is encoded using a refinement type alias of the same name with a `noStuttering` predicate. Most notably, this is non-trivially checked in `getContextDiffNumbered` postcondition by specifying its local functions `doPrefix` and `doSuffix` to transform an input `Hunk` into an intermediate form `{ds : [ValidListDiff c c] | noFFSS ds}` that `splitBothBoth` transforms back into a `Hunk`. The input `Hunk` (actually a stronger variant which also specifies the value contents to be non-empty) is produced by `getGroupedDiffBy`. 

The changes within `getGroupedDiffBy` are just reformating (to better accomodate the Liquid Haskell specifications) and the following renamings to improve readability:

```
go -> groupDiff
goFirsts -> leadingFirstss
goSeconds -> leading Seconds
goBoth -> leadingBoths
```

NOTE: Refinement type aliases--such as `{-@ type Hunk c = { h : [ValidListDiff c c] | noStuttering h} @-}` and `{-@ type ContextDiff c = [Hunk c] @-}`--override the corresponding type aliases--`type Hunk c = [Diff [c]]` and `type Hunk c = [Diff [c]` respectively--in Liquid Haskell specifications.

`PolyDiff` and `Diff` types and instances are moved to a new `Data.Algorithm.Diff.Type` module. This move is required to have functions defined solely for Liquid Haskell specifications in a separate module and avoid cyclic dependency; this helps prevent the cluther of implementation modules by (some of the) unused functions. Such functions reside in `Data.Algorithm.Diff.Refinement`, together with refinement type aliases that use them and other helpers required for specifications.