### PR TITLE
Prove termination of (optimized) diff algorithm implementation

### DIFF
--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -24,7 +24,10 @@ doBenchMarks seed =
   let rbools = randoms (mkStdGen seed) :: [Bool]
       (s1000_1, rbools1) = splitAt 1000 rbools
       (s1000_2, rbools2) = splitAt 1000 rbools1
-  in s1000_1 `deepseq` s1000_2 `deepseq` defaultMain [
-    bgroup "diff bool lists" $ [bench "1000 bools" $ nf (getDiff s1000_1) s1000_2]
-    ]
-    
+      s500_2 = take 500 s1000_2
+  in (s1000_1, s1000_2, s500_2) `deepseq` defaultMain
+      [ bgroup "diff bool lists"
+          [ bench "1000 bools" $ nf (getDiff s1000_1) s1000_2
+          , bench "1000/500 bools" $ nf (getDiff s1000_1) s500_2
+          ]
+      ]

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -143,6 +143,47 @@ _wfDiags :: Int -> [DL] -> Bool
 _wfDiags _ [] = True
 _wfDiags k (dl:dls) = poi dl - poj dl == k && _wfDiags (k - 2) dls
 
+--------------------------------------------------------------------------------
+-- [NOTE: diagonal-invariant]
+--
+-- The '_wfDiags' predicate states that succesive nodes in a wave front lie
+-- on diagonals whose indices differ by two. This is leveraged by LiquidHaskell
+-- to check that the 'furthestReaching' precondition stating that the two nodes
+-- it compares lie on the same diagonal is satisfied within `dstep`.
+-- However, even though a more flexible predicate could be used to prove it,
+-- a compromise was made in preserving this invariant to keep the specification
+-- complexity low at a negligible performance penalty cost.
+-- This note documents this compromise.
+--
+-- To prove 'ses' terminates, wave fronts are restricted to be within the
+-- edit grid. This is done by placing checks for boundary nodes within 'dstep'
+-- to avoid constructing nodes outside the grid. 'dstep' leverages such checks
+-- in optimizations that rely on the observation that boundary nodes signal
+-- other nodes cannot compete to the goal:
+--
+--  * If a bottom boundary is found, all subsequent nodes are not considered.
+--
+--  * If a right boundary is found, all previously constructed child nodes
+--    can be dropped.
+--
+-- Both preserve the diagonal invariant, as the wave front would just become
+-- narrower. However, due to the asymmetry of list traversal, the first one is
+-- readily implemented, while the second requires an additional operation whose
+-- cost trumps the gain of not keeping them for next iterations (according to the
+-- existing benchmarks). Because of this, and 'stepAndMege' looking a two
+-- succesive nodes at a time, only the current iteration child /could/ be
+-- effectively dropped.
+--
+-- However, dropping the current iteration child node results in wave fronts
+-- with holes: now for every right boundary node found, a diagonal is not
+-- occupied. This requires the diagonal invariant to be changed to "diagonal
+-- indices in succesive nodes of a wave front differ by 2, unless a node lies
+-- on the right boundary, in which case its diagonal must differ from the previous
+-- by a factor of 2". It was decided to not follow this path, because the gain
+-- of not keeping this node was found to be negligible compared with the resulting
+-- increase in specification complexity.
+--------------------------------------------------------------------------------
+
 -- A wave front is a list of 'DL' nodes, all at the same edit distance @D@,
 -- with k-diagonals @D@, @D−2@, …, @-D+2@, @-D@.
 {-@ type WaveFront D = {xs : [DLN D] | _wfDiags D xs} @-}
@@ -242,7 +283,11 @@ dstep
 -- @lena@, @lenb@ and @_d@ are named in the first equation as a workaround
 -- to https://github.com/ucsd-progsys/liquidhaskell/issues/2704
 dstep lena lenb _ _d [] = error "dstep: Cannot perform expansion on an empty list of nodes"
-dstep lena lenb cd _ (dl:dls) = addsnake lena lenb cd (hStep dl) : stepAndMerge dl dls
+-- This definition branches according to whether a node is on a boundary
+-- to avoid constructing out-of-bound nodes and discarding other non-competing nodes.
+dstep lena lenb cd _ (dl:dls) =
+  if poi dl >= lena then stepAndMerge dl dls
+  else addsnake lena lenb cd (hStep dl) : stepAndMerge dl dls
   where
     {-@ hStep :: x : DLN _d -> {v : DLN (_d + 1) | _kdiag v = _kdiag x + 1} @-}
     hStep node = node {poi = poi node + 1, path = F : path node}
@@ -255,10 +300,21 @@ dstep lena lenb cd _ (dl:dls) = addsnake lena lenb cd (hStep dl) : stepAndMerge 
                      -> {rest : [DLN _d] | _wfDiags (_kdiag prev - 2) rest}
                      -> {v : [DLN (_d+1)] | _wfDiags (_kdiag prev - 1) v && len v = len rest + 1}
                      / [len rest] @-}
-    stepAndMerge :: DL -> [DL] -> [DL]
-    stepAndMerge prev [] = [addsnake lena lenb cd $ vStep prev]
-    stepAndMerge prev (next:rest) =
-      addsnake lena lenb cd (furthestReaching (vStep prev) (hStep next)) : stepAndMerge next rest
+    stepAndMerge prev nodes =
+      -- When a node lies in the bottom boundary no subsequent node can reach
+      -- the goal faster.
+      if poj prev >= lenb then []
+      else case nodes of
+        [] -> [addsnake lena lenb cd $ vStep prev]
+        (next:rest) ->
+            -- The next node being on the right border implies 'hStep' would
+            -- produce a node outside the grid, but also that previous node's
+            -- children cannot compete to the endpoint.
+            -- However, we keep @prev@'s vertical child node to preserve
+            -- the '_wfDiags' invariant at a negligible performance penalty.
+            -- See [NOTE: diagonal-invariant]
+            if poi next >= lena then vStep prev : stepAndMerge next rest
+            else addsnake lena lenb cd (furthestReaching (vStep prev) (hStep next)) : stepAndMerge next rest
 
 -- | Follow a /snake/ from the current position of a 'DL' node.
 --
@@ -347,8 +403,6 @@ getGroupedDiff = getGroupedDiffBy (==)
 -- | A form of 'getDiff' with no 'Eq' constraint. Instead, an equality predicate
 -- is taken as the first argument.
 getDiffBy :: (a -> b -> Bool) -> [a] -> [b] -> [PolyDiff a b]
-getDiffBy _ a [] = map First a
-getDiffBy _ [] b = map Second b
 getDiffBy eq a b = markup a b . reverse $ ses eq a b
     where markup (x:xs) (y:ys) ds
             | eq x y = Both x y : markup xs ys ds

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -348,13 +348,26 @@ endPoint lena lenb dl = poi dl == lena && poj dl == lenb
 --
 -- The first two 'Int' parameters stand for the lengths of the input lists,
 -- which are captured from the outer scope to compute them only once.
-canDiag :: (a -> b -> Bool) -> [a] -> [b] -> Int -> Int -> Int -> Int -> Bool
-canDiag eq as bs lena lenb = \ i j ->
-   if i < lena && j < lenb then (arAs ! i) `eq` (arBs ! j) else False
-   where
-     -- Lists are converted into arrays to have O(1) lookups.
-     arAs = listArray (0,lena - 1) as
-     arBs = listArray (0,lenb - 1) bs
+{-@
+canDiag :: (a -> b -> Bool)
+        -> [a]
+        -> [b]
+        -> lena : Int
+        -> lenb : Int
+        -> DiagPred lena lenb
+@-}
+canDiag :: (a -> b -> Bool) -- ^ Custom equality predicate
+        -> [a] -- ^ First input
+        -> [b] -- ^ Second input
+        -> Int -- ^ First input's length
+        -> Int -- ^ Second input's lenth
+        -> (Int -> Int -> Bool) -- ^ Diagonal predicate on the edit grid
+canDiag eq as bs lena lenb = \i j ->
+  (i < lena && j < lenb) && ((arAs ! i) `eq` (arBs ! j))
+  where
+    -- Lists are converted into arrays to have O(1) lookups.
+    arAs = listArray (0,lena - 1) as
+    arBs = listArray (0,lenb - 1) bs
 
 -- | Perform one breadth-first search expansion step, advancing every wave front
 -- 'DL' node by one 'DI' edit (one non-diagonal edge) and then following
@@ -487,7 +500,6 @@ addsnake lena lenb cd dl
     | otherwise   = dl
     where pi = poi dl; pj = poj dl
 
-{-@ ignore ses @-}
 -- | Compute shortest edit script (SES), as the minimum sequence of 'DI' edit
 -- steps that transforms @as@ into @bs@, returned in reverse order.
 --
@@ -516,6 +528,11 @@ ses eq as bs = path $ searchEndpoint 0 [addsnake lena lenb cd (DL 0 0 [])]
   where
     cd = canDiag eq as bs lena lenb
     lena = length as; lenb = length bs
+    {-@ searchEndpoint
+          :: d : Nat
+          -> {dls : WaveFront lena lenb d | len dls > 0}
+          -> {v : DL | endPoint lena lenb v}
+          / [_wfDistanceToGoal lena lenb dls] @-}
     searchEndpoint :: Int -> [DL] -> DL
     searchEndpoint _ [] = error "ses: The search must have a seed node"
     searchEndpoint d wf = case findEndpoint lena lenb wf of
@@ -526,6 +543,11 @@ ses eq as bs = path $ searchEndpoint 0 [addsnake lena lenb cd (DL 0 0 [])]
     -- The abstract refinement @q@ lets 'find' carry the wave
     -- front element refinement (notably @len (path dl) == d@)
     -- over to the returned endpoint.
+    {-@ assume findEndpoint
+          :: forall <q :: DL -> Bool>.
+             i : Nat -> j : Nat -> xs : [DL<q>]
+          -> { m : Maybe {dl : DL<q> | endPoint i j dl}
+             | m == Nothing => _wfDistanceToGoal i j xs > 0} @-}
     findEndpoint :: Int -> Int -> [DL] -> Maybe DL
     findEndpoint i j = find (endPoint i j)
 

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -125,81 +125,6 @@ data DL = DL
                      --   'S' steps are stored.
     } deriving (Show, Eq)
 
--- Field refinements are implemented with measures, which means they are
--- available only when a 'DL' value is pattern matched;
--- This invariant on DLs makes the coordinates non-negativity available
--- for any value of type 'DL' regardless of whether it has been pattern matched.
-{-@ using (DL) as { dl : DL | poi dl >= 0 && poj dl >= 0 } @-}
-
--- A "D-path location node" is a 'DL' value within the edit grid bounds
--- having a fixed /D-length/.
-{-@ type DLN M N D = { x : DL | len (path x) = D && _withinBounds M N x} @-}
-
-{-@ reflect _kdiag @-}
--- | Computes the k-diagonal of a node.
--- Used in LiquidHaskell logic as an expression.
-_kdiag :: DL -> Int
-_kdiag dl = poi dl - poj dl
-
-{-@ reflect _wfDiags @-}
-{-@ _wfDiags :: Int -> xs : [DL] -> Bool / [len xs] @-}
--- | Checks if succesive nodes of a wave front lie within k-diagonals
--- differing by 2 as described in the Myers algorithm.
--- Used in LiquidHaskell logic as a predicate.
-_wfDiags :: Int -> [DL] -> Bool
-_wfDiags _ [] = True
-_wfDiags k (dl:dls) = _kdiag dl == k && _wfDiags (k - 2) dls
-
---------------------------------------------------------------------------------
--- [NOTE: diagonal-invariant]
---
--- The '_wfDiags' predicate states that succesive nodes in a wave front lie
--- on diagonals whose indices differ by two. This is leveraged by LiquidHaskell
--- to check that the 'furthestReaching' precondition stating that the two nodes
--- it compares lie on the same diagonal is satisfied within `dstep`.
--- However, even though a more flexible predicate could be used to prove it,
--- a compromise was made in preserving this invariant to keep the specification
--- complexity low at a negligible performance penalty cost.
--- This note documents this compromise.
---
--- To prove 'ses' terminates, wave fronts are restricted to be within the
--- edit grid. This is done by placing checks for boundary nodes within 'dstep'
--- to avoid constructing nodes outside the grid. 'dstep' leverages such checks
--- in optimizations that rely on the observation that boundary nodes signal
--- other nodes cannot compete to the goal:
---
---  * If a bottom boundary is found, all subsequent nodes are not considered.
---
---  * If a right boundary is found, all previously constructed child nodes
---    can be dropped.
---
--- Both preserve the diagonal invariant, as the wave front would just become
--- narrower. However, due to the asymmetry of list traversal, the first one is
--- readily implemented, while the second requires an additional operation whose
--- cost trumps the gain of not keeping them for next iterations (according to the
--- existing benchmarks). Because of this, and 'stepAndMege' looking a two
--- succesive nodes at a time, only the current iteration child /could/ be
--- effectively dropped.
---
--- However, dropping the current iteration child node results in wave fronts
--- with holes: now for every right boundary node found, a diagonal is not
--- occupied. This requires the diagonal invariant to be changed to "diagonal
--- indices in succesive nodes of a wave front differ by 2, unless a node lies
--- on the right boundary, in which case its diagonal must differ from the previous
--- by a factor of 2". It was decided to not follow this path, because the gain
--- of not keeping this node was found to be negligible compared with the resulting
--- increase in specification complexity.
---------------------------------------------------------------------------------
-
--- A wave front is a list of 'DL' nodes, all at the same edit distance @D@,
--- with k-diagonals @D@, @D−2@, …, @-D+2@, @-D@.
--- Wave fronts establish a connection with the Myers algorithm:
--- @D@ corresponds to the algorithm's current iteration step and the resulting
--- 'ses' length. In Myers the diagonal arrangement is used to optimize space;
--- within 'dstep' it allows us to ensure 'furthestReaching' always compares
--- nodes on the same diagonals.
-{-@ type WaveFront M N D = {xs : [DLN M N D] | _wfDiags (_kdiag (head xs)) xs} @-}
-
 {-@ reflect furthestReaching @-}
 -- | Select the furthest-reaching candidate of two 'DL' nodes competing for the
 -- same k-diagonal, as required by the Myers algorithm.
@@ -224,120 +149,6 @@ furthestReaching :: DL -> DL -> DL
 furthestReaching x y
   | poi x >= poi y = x
   | otherwise      = y
-
--- * Proving the algorithm termination in Liquid Haskell
---
--- The original algorithm is known to terminate because a wave front /eventually/ reaches the 'endPoint'.
--- To prove this, both inputs lengths are threaded within phantom parameters throughout the implementation.
--- In essence, both lengths are used to encode the edit grid and its end point.
-
-{-@ reflect _manhattanDistance @-}
-_manhattanDistance :: Int -> Int -> DL -> Int
-_manhattanDistance lena lenb dl  = lena - (poi dl) + lenb - (poj dl)
-
-{-@ reflect _wfDistanceToGoal @-}
--- | The smallest manhattan distance from a wave front node to the goal @(lena, lenb)@.
--- The empty wave front yields @lena + lenb + 2@, a sentinel strictly greater
--- than any in-bounds node's distance, acting as the identity for the minimum.
-_wfDistanceToGoal :: Int -> Int -> [DL] -> Int
-_wfDistanceToGoal lena lenb [] = lena + lenb + 2
-_wfDistanceToGoal lena lenb (dl:dls) =
-  -- We avoid using 'min' here so that LH can unfold this definition.
-  if _manhattanDistance lena lenb dl < _wfDistanceToGoal lena lenb dls
-  then _manhattanDistance lena lenb dl
-  else _wfDistanceToGoal lena lenb dls
-
--- | A lemma that expresses a lower bound of the wavefront distance in terms
--- of the diagonal of the first node: @lena - lenb - k@
---
--- We assume all the nodes to be within the grid.
---
--- @lena - lenb@ is the diagonal of the goal. Informally, the
--- shortest way from a node must necessarily visit all the intermediate
--- diagonals. The minimum amount of diagonals to visit is given by the
--- difference between the diagonal indices of the goal and the first element.
---
--- We can prove it manually like so:
---
--- For every node @dl = DL i j p@ we can prove
--- @H(dl) = _manhattanDistance lena lenb dl >= lena - lenb - (i - j)@
---
--- @
---   _manhattanDistance lena lenb dl
--- =
---   lena - (poi dl) + lenb - (poj dl)
--- =
---   lena - i + lenb - j
--- =
---   lena - lenb - (i - j) + 2 * (lenb - j)
--- >=
---   lena - lenb - (i - j)
--- @
---
--- Since @H(dl)@ holds for every node in the wave front, it follows
--- that the wave front distance is at least as large as the smallest of
--- these bounds, which is @lena - lenb - k@ for the largest @k = i0 - j0@,
--- which is the diagonal of the first node.
---
--- QED
--- @
-{-@ _wfDistanceLowerBoundK
-      :: lena : Nat -> lenb : Nat -> {k : Int | lenb + k + 2 >= 0}
-      -> xs : {v : [{dl : DL | _withinBounds lena lenb dl}] | _wfDiags k v}
-      -> {_wfDistanceToGoal lena lenb xs >= lena - lenb - k}
-      / [len xs] @-}
-_wfDistanceLowerBoundK :: Int -> Int -> Int -> [DL] -> ()
-_wfDistanceLowerBoundK _    _    _ []      = ()
-_wfDistanceLowerBoundK lena lenb k (_:dls) = _wfDistanceLowerBoundK lena lenb (k - 2) dls
-
--- | If a wave front's node (@prev@) is on the bottom boundary, then the following
--- nodes lie farther from the goal. Intuitively, the reason is that the following
--- nodes children would need more steps to cross @prev@'s diagonal to reach the goal.
--- This lemma allows LH to reason about the case where nodes are discarded
--- after a bottom-boundary node within 'dstep'.
-{-@
-_wfDistanceLowerBound
-      :: lena : Nat -> lenb : Nat -> {prev : DL | _withinBounds lena lenb prev}
-      -> xs : {v : [{dl : DL | _withinBounds lena lenb dl}] | _wfDiags (_kdiag prev - 2) v}
-      -> { poj prev >= lenb =>  _wfDistanceToGoal lena lenb xs > _manhattanDistance lena lenb prev}
- @-}
-_wfDistanceLowerBound :: Int -> Int -> DL -> [DL] -> ()
-_wfDistanceLowerBound lena lenb prev [] = ()
-_wfDistanceLowerBound lena lenb prev xs@(_:_) = ()
-  where
-    _lemma = _wfDistanceLowerBoundK lena lenb (_kdiag prev - 2) xs
-
-
--- | The termination metric is non-negative: every in-bounds node has a
--- non-negative manhattan distance to the goal, and the empty wave front
--- yields the positive sentinel. Needed because the @Nat@ result refinement
--- of the reflected '_wfDistanceToGoal' is not instantiated at logic-level
--- applications, while termination metrics must be provably non-negative.
-{-@ _minDistanceNonNegative
-      :: lena : Nat -> lenb : Nat
-      -> xs : [{dl : DL | _withinBounds lena lenb dl}]
-      -> {_wfDistanceToGoal lena lenb xs >= 0}
-      / [len xs] @-}
-_minDistanceNonNegative :: Int -> Int -> [DL] -> ()
-_minDistanceNonNegative _    _    []       = ()
-_minDistanceNonNegative lena lenb (_:dls) = _minDistanceNonNegative lena lenb dls
-
-{-@ inline _reducesDistanceToGoal @-}
-_reducesDistanceToGoal :: Int -> Int -> [DL] -> [DL] -> Bool
-_reducesDistanceToGoal lena lenb wf1 wf2 = _wfDistanceToGoal lena lenb wf2 < _wfDistanceToGoal lena lenb wf1
-
-{-@ inline _withinBounds @-}
-{-@ _withinBounds :: lena : Nat -> lenb : Nat -> dl : DL -> {v:Bool | v <=> (poi dl <= lena && poj dl <= lenb) } @-}
-_withinBounds :: Int -> Int -> DL -> Bool
-_withinBounds lena lenb dl = poi dl <= lena && poj dl <= lenb
-
-{-@ inline endPoint @-}
-endPoint :: Int -> Int -> DL -> Bool
-endPoint lena lenb dl = poi dl == lena && poj dl == lenb
-
--- This refinement type alias allows LiquidHaskell to reason about the function
--- parameter of 'addsnake' that establishes whether coordinates are within bounds.
-{-@ type DiagPred M N = i : Nat -> j : Nat -> {b : Bool | ((i >= M || j >= N) => not b)} @-}
 
 -- | Build a /diagonal predicate/ — a closure that tests whether position
 -- @(i, j)@ in the edit graph has a diagonal edge (a /match point/ in Myers'
@@ -641,3 +452,212 @@ getGroupedDiffBy eq a b = groupDiff $ getDiffBy eq a b
     leadingBoths (Both w z : diffs) = let (as, bs, rest) = leadingBoths diffs
                                        in (w:as, z:bs, rest)
     leadingBoths diffs = ([], [], diffs)
+
+--------------------------------------------------------------------------------
+-- * LiquidHaskell Wave Front Specification
+--
+-- Wave fronts establish a connection between the orignal the Myers algorithm
+-- and this implementation:
+-- Their nodes carry the edit distance, which also corresponds to the
+-- algorithm's current iteration step and the resulting 'ses' length.
+-- In Myers the diagonal arrangement invariant of the iteration is used to
+-- optimize space; within 'dstep' it allows us to ensure 'furthestReaching'
+-- always compares nodes on the same diagonals.
+--------------------------------------------------------------------------------
+
+-- Field refinements are implemented with measures, which means they are
+-- available only when a 'DL' value is pattern matched;
+-- This invariant on DLs makes the coordinates non-negativity available
+-- for any value of type 'DL' regardless of whether it has been pattern matched.
+{-@ using (DL) as { dl : DL | poi dl >= 0 && poj dl >= 0 } @-}
+
+-- A "D-path location node" is a 'DL' value within the edit grid bounds
+-- having a fixed /D-length/.
+{-@ type DLN M N D = { x : DL | len (path x) = D && _withinBounds M N x} @-}
+
+{-@ reflect _kdiag @-}
+-- | Computes the k-diagonal of a node.
+-- Used in LiquidHaskell logic as an expression.
+_kdiag :: DL -> Int
+_kdiag dl = poi dl - poj dl
+
+{-@ reflect _wfDiags @-}
+{-@ _wfDiags :: Int -> xs : [DL] -> Bool / [len xs] @-}
+-- | Checks if succesive nodes of a wave front lie within k-diagonals
+-- differing by 2 as described in the Myers algorithm.
+-- Used in LiquidHaskell logic as a predicate.
+-- See [NOTE: diagonal-invariant]
+_wfDiags :: Int -> [DL] -> Bool
+_wfDiags _ [] = True
+_wfDiags k (dl:dls) = _kdiag dl == k && _wfDiags (k - 2) dls
+
+--------------------------------------------------------------------------------
+-- [NOTE: diagonal-invariant]
+--
+-- The '_wfDiags' predicate states that succesive nodes in a wave front lie
+-- on diagonals whose indices differ by two. This is leveraged by LiquidHaskell
+-- to check that the 'furthestReaching' precondition stating that the two nodes
+-- it compares lie on the same diagonal is satisfied within `dstep`.
+-- However, even though a more flexible predicate could be used to prove it,
+-- a compromise was made in preserving this invariant to keep the specification
+-- complexity low at a negligible performance penalty cost.
+-- This note documents this compromise.
+--
+-- To prove 'ses' terminates, wave fronts are restricted to be within the
+-- edit grid. This is done by placing checks for boundary nodes within 'dstep'
+-- to avoid constructing nodes outside the grid. 'dstep' leverages such checks
+-- in optimizations that rely on the observation that boundary nodes signal
+-- other nodes cannot compete to the goal:
+--
+--  * If a bottom boundary is found, all subsequent nodes are not considered.
+--
+--  * If a right boundary is found, all previously constructed child nodes
+--    can be dropped.
+--
+-- Both preserve the diagonal invariant, as the wave front would just become
+-- narrower. However, due to the asymmetry of list traversal, the first one is
+-- readily implemented, while the second requires an additional operation whose
+-- cost trumps the gain of not keeping them for next iterations (according to the
+-- existing benchmarks). Because of this, and 'stepAndMege' looking a two
+-- succesive nodes at a time, only the current iteration child /could/ be
+-- effectively dropped.
+--
+-- However, dropping the current iteration child node results in wave fronts
+-- with holes: now for every right boundary node found, a diagonal is not
+-- occupied. This requires the diagonal invariant to be changed to "diagonal
+-- indices in succesive nodes of a wave front differ by 2, unless a node lies
+-- on the right boundary, in which case its diagonal must differ from the previous
+-- by a factor of 2". It was decided to not follow this path, because the gain
+-- of not keeping this node was found to be negligible compared with the resulting
+-- increase in specification complexity.
+--------------------------------------------------------------------------------
+
+-- A wave front is a list of 'DL' nodes, all at the same edit distance @D@,
+-- with k-diagonals @D@, @D−2@, …, @-D+2@, @-D@.
+-- See [NOTE: diagonal-invariant]
+{-@ type WaveFront M N D = {xs : [DLN M N D] | _wfDiags (_kdiag (head xs)) xs} @-}
+
+--------------------------------------------------------------------------------
+-- * Proving the Algorithm's Termination in LiquidHaskell
+--
+-- The `ses` (_smallest edit script_) function termination is proved by defining
+-- a wave front's distance to the _endpoint_ as decreasing metric.
+-- This function is the implementation's entry point to the Myers diff algorithm,
+-- whose original specification waives the need for a termination proof by
+-- bounding the algorithm's outer loop by the known worst case edit script length,
+-- i.e. the sum of both input's lengths. These lengths are threaded through the
+-- implementation as phantom parameters for the following helpers to provide the
+-- LiquidHaskell specification a notion of the edit grid (as nodes '_withinBounds')
+-- and its end point.
+--------------------------------------------------------------------------------
+
+{-@ reflect _manhattanDistance @-}
+_manhattanDistance :: Int -> Int -> DL -> Int
+_manhattanDistance lena lenb dl  = lena - (poi dl) + lenb - (poj dl)
+
+{-@ reflect _wfDistanceToGoal @-}
+-- | The smallest manhattan distance from a wave front node to the goal @(lena, lenb)@.
+-- The empty wave front yields @lena + lenb + 2@, a sentinel strictly greater
+-- than any in-bounds node's distance, acting as the identity for the minimum.
+_wfDistanceToGoal :: Int -> Int -> [DL] -> Int
+_wfDistanceToGoal lena lenb [] = lena + lenb + 2
+_wfDistanceToGoal lena lenb (dl:dls) =
+  -- We avoid using 'min' here so that LH can unfold this definition.
+  if _manhattanDistance lena lenb dl < _wfDistanceToGoal lena lenb dls
+  then _manhattanDistance lena lenb dl
+  else _wfDistanceToGoal lena lenb dls
+
+{-@ inline _reducesDistanceToGoal @-}
+_reducesDistanceToGoal :: Int -> Int -> [DL] -> [DL] -> Bool
+_reducesDistanceToGoal lena lenb wf1 wf2 =
+  _wfDistanceToGoal lena lenb wf2 < _wfDistanceToGoal lena lenb wf1
+
+{-@ inline _withinBounds @-}
+{-@ _withinBounds :: lena : Nat -> lenb : Nat -> dl : DL
+                   -> {v:Bool | v <=> (poi dl <= lena && poj dl <= lenb) } @-}
+_withinBounds :: Int -> Int -> DL -> Bool
+_withinBounds lena lenb dl = poi dl <= lena && poj dl <= lenb
+
+{-@ inline endPoint @-}
+endPoint :: Int -> Int -> DL -> Bool
+endPoint lena lenb dl = poi dl == lena && poj dl == lenb
+
+-- This refinement type alias allows LiquidHaskell to reason about the function
+-- parameter of 'addsnake' that establishes whether coordinates are within bounds.
+{-@ type DiagPred M N = i : Nat -> j : Nat -> {b : Bool | b => i < M && j < N} @-}
+
+-- | A lemma that expresses a lower bound of the wavefront distance in terms
+-- of the diagonal of the first node: @lena - lenb - k@
+--
+-- We assume all the nodes to be within the grid.
+--
+-- @lena - lenb@ is the diagonal of the goal. Informally, the
+-- shortest way from a node must necessarily visit all the intermediate
+-- diagonals. The minimum amount of diagonals to visit is given by the
+-- difference between the diagonal indices of the goal and the first element.
+--
+-- We can prove it manually like so:
+--
+-- For every node @dl = DL i j p@ we can prove
+-- @H(dl) = _manhattanDistance lena lenb dl >= lena - lenb - (i - j)@
+--
+-- @
+--   _manhattanDistance lena lenb dl
+-- =
+--   lena - (poi dl) + lenb - (poj dl)
+-- =
+--   lena - i + lenb - j
+-- =
+--   lena - lenb - (i - j) + 2 * (lenb - j)
+-- >=
+--   lena - lenb - (i - j)
+-- @
+--
+-- Since @H(dl)@ holds for every node in the wave front, it follows
+-- that the wave front distance is at least as large as the smallest of
+-- these bounds, which is @lena - lenb - k@ for the largest @k = i0 - j0@,
+-- which is the diagonal of the first node.
+--
+-- QED
+-- @
+{-@ _wfDistanceLowerBoundK
+      :: lena : Nat -> lenb : Nat -> {k : Int | lenb + k + 2 >= 0}
+      -> xs : {v : [{dl : DL | _withinBounds lena lenb dl}] | _wfDiags k v}
+      -> {_wfDistanceToGoal lena lenb xs >= lena - lenb - k}
+      / [len xs] @-}
+_wfDistanceLowerBoundK :: Int -> Int -> Int -> [DL] -> ()
+_wfDistanceLowerBoundK _    _    _ []      = ()
+_wfDistanceLowerBoundK lena lenb k (_:dls) = _wfDistanceLowerBoundK lena lenb (k - 2) dls
+
+-- | If a wave front's node (@prev@) is on the bottom boundary, then the following
+-- nodes lie farther from the goal. Intuitively, the reason is that the following
+-- nodes children would need more steps to cross @prev@'s diagonal to reach the goal.
+-- This lemma allows LH to reason about the case where nodes are discarded
+-- after a bottom-boundary node within 'dstep'.
+{-@
+_wfDistanceLowerBound
+      :: lena : Nat -> lenb : Nat -> {prev : DL | _withinBounds lena lenb prev}
+      -> xs : {v : [{dl : DL | _withinBounds lena lenb dl}] | _wfDiags (_kdiag prev - 2) v}
+      -> { poj prev >= lenb =>  _wfDistanceToGoal lena lenb xs > _manhattanDistance lena lenb prev}
+ @-}
+_wfDistanceLowerBound :: Int -> Int -> DL -> [DL] -> ()
+_wfDistanceLowerBound lena lenb prev [] = ()
+_wfDistanceLowerBound lena lenb prev xs@(_:_) = ()
+  where
+    _lemma = _wfDistanceLowerBoundK lena lenb (_kdiag prev - 2) xs
+
+
+-- | The termination metric is non-negative: every in-bounds node has a
+-- non-negative manhattan distance to the goal, and the empty wave front
+-- yields the positive sentinel. This lemma is needed because the @Nat@ result
+-- refinement of the reflected '_wfDistanceToGoal' is not instantiated at
+-- logic-level  applications, while termination metrics must be provably
+-- non-negative.
+{-@ _minDistanceNonNegative
+      :: lena : Nat -> lenb : Nat
+      -> xs : [{dl : DL | _withinBounds lena lenb dl}]
+      -> {_wfDistanceToGoal lena lenb xs >= 0}
+      / [len xs] @-}
+_minDistanceNonNegative :: Int -> Int -> [DL] -> ()
+_minDistanceNonNegative _    _    []       = ()
+_minDistanceNonNegative lena lenb (_:dls) = _minDistanceNonNegative lena lenb dls

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -169,6 +169,20 @@ furthestReaching x y
   | poi x >= poi y = x
   | otherwise      = y
 
+-- * Proving the algorithm termination in Liquid Haskell
+--
+-- The original algorithm is known to terminate because a wave front /eventually/ reaches the 'endPoint'.
+-- To prove this, both inputs lengths are threaded within phantom parameters throughout the implementation.
+-- In essence, both lengths are used to encode the edit grid and its end point.
+
+{-@ reflect _manhattanDistance @-}
+_manhattanDistance :: Int -> Int -> DL -> Int
+_manhattanDistance lena lenb dl  = lena - (poi dl) + lenb - (poj dl)
+
+-- This refinement type alias allows LiquidHaskell to reason about the function
+-- parameter of 'addsnake' that establishes whether coordinates are within bounds.
+{-@ type DiagPred M N = i : Nat -> j : Nat -> {b : Bool | ((i >= M || j >= N) => not b)} @-}
+
 -- | Build a /diagonal predicate/ — a closure that tests whether position
 -- @(i, j)@ in the edit graph has a diagonal edge (a /match point/ in Myers'
 -- terminology).
@@ -186,6 +200,7 @@ canDiag eq as bs lena lenb = \ i j ->
      arAs = listArray (0,lena - 1) as
      arBs = listArray (0,lenb - 1) bs
 
+{-@ ignore dstep @-}
 -- | Perform one breadth-first search expansion step, advancing every wave front
 -- 'DL' node by one 'DI' edit (one non-diagonal edge) and then following
 -- any available snake.
@@ -210,22 +225,24 @@ canDiag eq as bs lena lenb = \ i j ->
 -- with one more node than the input.
 {-@
 dstep
-  :: (Nat -> Nat -> Bool)
+  :: lena : Nat
+  -> lenb : Nat
+  -> DiagPred lena lenb
   -> d : Nat
   -> {nodes : WaveFront d | len nodes > 0}
   -> {v : WaveFront (d + 1) | len v = len nodes + 1}
 @-}
 dstep
-  :: (Int -> Int -> Bool) -- ^ Diagonal predicate
+  :: Int                  -- ^ First input's length phantom parameter for termination check.
+  -> Int                  -- ^ Second input's length phantom parameter for termination check.
+  -> (Int -> Int -> Bool) -- ^ Diagonal predicate
   -> Int                  -- ^ The current D-length; used for the static check of wave front invariant.
   -> [DL]                 -- ^ A non-empty wave front of nodes at edit distance D
   -> [DL]                 -- ^ A non-empty wave front of nodes at edit distance D+1
--- NOTE: @_d@ is a phantom (apparently unused) parameter required by local LiquidHaskell specifications.
--- This parameter sits at the first equation as a workaround
--- to GHC removing it when desugaring multi-equation definitions.
--- See https://github.com/ucsd-progsys/liquidhaskell/issues/2704
-dstep _ _d [] = error "dstep: Cannot perform expansion on an empty list of nodes"
-dstep cd _ (dl:dls) = addsnake cd (hStep dl) : stepAndMerge dl dls
+-- @lena@, @lenb@ and @_d@ are named in the first equation as a workaround
+-- to https://github.com/ucsd-progsys/liquidhaskell/issues/2704
+dstep lena lenb _ _d [] = error "dstep: Cannot perform expansion on an empty list of nodes"
+dstep lena lenb cd _ (dl:dls) = addsnake lena lenb cd (hStep dl) : stepAndMerge dl dls
   where
     {-@ hStep :: x : DLN _d -> {v : DLN (_d + 1) | _kdiag v = _kdiag x + 1} @-}
     hStep node = node {poi = poi node + 1, path = F : path node}
@@ -239,11 +256,10 @@ dstep cd _ (dl:dls) = addsnake cd (hStep dl) : stepAndMerge dl dls
                      -> {v : [DLN (_d+1)] | _wfDiags (_kdiag prev - 1) v && len v = len rest + 1}
                      / [len rest] @-}
     stepAndMerge :: DL -> [DL] -> [DL]
-    stepAndMerge prev [] = [addsnake cd $ vStep prev]
+    stepAndMerge prev [] = [addsnake lena lenb cd $ vStep prev]
     stepAndMerge prev (next:rest) =
-      addsnake cd (furthestReaching (vStep prev) (hStep next)) : stepAndMerge next rest
+      addsnake lena lenb cd (furthestReaching (vStep prev) (hStep next)) : stepAndMerge next rest
 
-{-@ lazy addsnake @-}
 -- | Follow a /snake/ from the current position of a 'DL' node.
 --
 -- A snake is a sequence of diagonal (cost-free) edges in the edit graph,
@@ -252,10 +268,22 @@ dstep cd _ (dl:dls) = addsnake cd (hStep dl) : stepAndMerge dl dls
 -- @(poi dl, poj dl)@, this function advances both 'poi' and 'poj' as long
 -- as consecutive elements match, leaving 'path' unchanged (diagonal moves
 -- are not recorded as edit steps).
-{-@ addsnake :: (Nat -> Nat -> Bool) -> x : DL -> {v : DL | path v == path x && _kdiag v = _kdiag x} @-}
-addsnake :: (Int -> Int -> Bool) -> DL -> DL
-addsnake cd dl
-    | cd pi pj = addsnake cd $
+{-@
+addsnake :: lena : Nat
+         -> lenb : Nat
+         -> DiagPred lena lenb
+         -> dl : DL
+         -> {v : DL | path v == path dl
+                   && _kdiag v = _kdiag dl}
+         / [_manhattanDistance lena lenb dl]
+@-}
+addsnake :: Int                  -- ^ First input's length phantom parameter for termination check.
+         -> Int                  -- ^ Second input's length phantom parameter for termination check.
+         -> (Int -> Int -> Bool) -- ^ Diagonal predicate, a.k.a. 'canDiag'
+         -> DL
+         -> DL
+addsnake lena lenb cd dl
+    | cd pi pj = addsnake lena lenb cd $
                  dl {poi = pi + 1, poj = pj + 1, path = path dl}
     | otherwise   = dl
     where pi = poi dl; pj = poj dl
@@ -290,7 +318,7 @@ addsnake cd dl
 -- unchanged.
 ses :: (a -> b -> Bool) -> [a] -> [b] -> [DI]
 ses eq as bs = path . head . dropWhile (\dl -> poi dl /= lena || poj dl /= lenb) .
-            concat . iterate (uncurry (dstep cd) . withD) . (:[]) . addsnake cd $
+            concat . iterate (uncurry (dstep lena lenb cd) . withD) . (:[]) . addsnake lena lenb cd $
             DL {poi=0,poj=0,path=[]}
             where cd = canDiag eq as bs lena lenb
                   lena = length as; lenb = length bs

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -135,7 +135,7 @@ data DL = DL
 -- having a fixed /D-length/.
 {-@ type DLN M N D = { x : DL | len (path x) = D && _withinBounds M N x} @-}
 
-{-@ inline _kdiag @-}
+{-@ reflect _kdiag @-}
 -- | Computes the k-diagonal of a node.
 -- Used in LiquidHaskell logic as an expression.
 _kdiag :: DL -> Int
@@ -148,7 +148,7 @@ _kdiag dl = poi dl - poj dl
 -- Used in LiquidHaskell logic as a predicate.
 _wfDiags :: Int -> [DL] -> Bool
 _wfDiags _ [] = True
-_wfDiags k (dl:dls) = poi dl - poj dl == k && _wfDiags (k - 2) dls
+_wfDiags k (dl:dls) = _kdiag dl == k && _wfDiags (k - 2) dls
 
 --------------------------------------------------------------------------------
 -- [NOTE: diagonal-invariant]
@@ -369,6 +369,14 @@ canDiag eq as bs lena lenb = \i j ->
     arAs = listArray (0,lena - 1) as
     arBs = listArray (0,lenb - 1) bs
 
+{-@ reflect hStep @-}
+hStep :: DL -> DL
+hStep node = node {poi = poi node + 1, path = F : path node}
+
+{-@ reflect vStep @-}
+vStep :: DL -> DL
+vStep node = node {poj = poj node + 1, path = S : path node}
+
 -- | Perform one breadth-first search expansion step, advancing every wave front
 -- 'DL' node by one 'DI' edit (one non-diagonal edge) and then following
 -- any available snake.
@@ -423,14 +431,6 @@ dstep lena lenb cd _ (dl:dls) =
       -- the goal than @dl@'s horizontal child.
       `const` _wfDistanceLowerBound lena lenb dl dls
   where
-    {-@ hStep
-          :: x : DLN lena lenb _d
-          -> {v : DL | len (path v) = _d + 1 && poi v = poi x + 1 && poj v = poj x} @-}
-    hStep node = node {poi = poi node + 1, path = F : path node}
-    {-@ vStep
-          :: x : DLN lena lenb _d
-          -> {v : DL | len (path v) = _d + 1 && poi v = poi x && poj v = poj x + 1} @-}
-    vStep node = node {poj = poj node + 1, path = S : path node}
     -- Merge vertical step of previous node with horizontal step of next node,
     -- selecting the furthest-reaching candidate for each shared k-diagonal,
     -- and extend it along matching elements.

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -78,6 +78,7 @@ import Data.Array (listArray, (!))
 import Data.Algorithm.Diff.Type
 import Data.Algorithm.Diff.Refinement (fst3, snd3, thd3, headIsFirst,
                                         headIsSecond, headIsBoth, noStuttering)
+import Data.Foldable (find)
 
 -- | /Diff Instruction/ — an internal enum recording the direction of a single
 -- non-diagonal edge traversed in the Myers edit graph. Every non-diagonal
@@ -490,37 +491,43 @@ addsnake lena lenb cd dl
 -- | Compute shortest edit script (SES), as the minimum sequence of 'DI' edit
 -- steps that transforms @as@ into @bs@, returned in reverse order.
 --
--- @ses eq as bs@ runs the Myers O(ND) diff algorithm following
--- a five-step pipeline:
+-- @ses eq as bs@ runs the Myers O(ND) diff algorithm:
 --
--- 1. __Seed__: create an initial 0-path wave front @[addsnake cd (DL 0 0 [])]@
+-- 1. __Seed__: create an initial 0-path wave front @[addsnake lena lenb cd (DL 0 0 [])]@
 --    having a single node on the tip of the longest origin-sourced snake.
--- 2. __Iterate__: apply 'dstep' repeatedly via 'iterate', producing an
---    infinite list of wave fronts (one per edit distance D = 0, 1, 2, …).
--- 3. __Flatten__: 'concat' all wave fronts into a single stream of 'DL' nodes.
--- 4. __Find__: 'dropWhile' skips nodes until one reaches @(lena, lenb)@ — the
---    bottom-right corner of the edit graph — which is the terminal node of a
---    shortest edit script.
--- 5. __Extract__: 'head' returns that node; its 'path' field carries the edit
+-- 2. __Search__: for each wave front at edit distance \( D = 0, 1, \ldots \),
+--    check whether any node has reached the goal @(lena, lenb)@. If not,
+--    apply 'dstep' to advance to edit distance \( D+1 \).
+-- 3. __Extract__: the first goal node's 'path' field carries the edit
 --    trace in reverse order.
 --
--- This implementation is purely functional: rather than updating a shared
--- diagonal frontier array in place, as in the original paper, it builds a new
--- list of 'DL' nodes for each value of \( D \) and concatenates them into
--- a single lazy stream. This is simpler but carries a larger per-node overhead:
--- each 'DL' holds its own edit trace as a @['DI']@ list that structurally
--- shares its tail with the parent node's trace (consing one step reuses the
--- existing spine), rather than the paper's single-integer-per-diagonal
--- representation. The asymptotic time
+-- This implementation deviates from the paper in the folowing way:
+-- rather than updating a shared diagonal frontier array in place,
+-- as in the original paper, it builds a new list of 'DL' nodes
+-- for each value of \( D \). This is simpler but carries a
+-- larger per-node overhead: each 'DL' holds its own edit trace as a @['DI']@
+-- list that structurally shares its tail with the parent node's trace (consing
+-- one step reuses the existing spine), rather than the paper's
+-- single-integer-per-diagonal representation. The asymptotic time
 -- and space complexity — \( O(ND) \) and \( O(D^2) \) respectively — is
 -- unchanged.
 ses :: (a -> b -> Bool) -> [a] -> [b] -> [DI]
-ses eq as bs = path . head . dropWhile (\dl -> poi dl /= lena || poj dl /= lenb) .
-            concat . iterate (uncurry (dstep lena lenb cd) . withD) . (:[]) . addsnake lena lenb cd $
-            DL {poi=0,poj=0,path=[]}
-            where cd = canDiag eq as bs lena lenb
-                  lena = length as; lenb = length bs
-                  withD xs = (length . path . head $ xs, xs)
+ses eq as bs = path $ searchEndpoint 0 [addsnake lena lenb cd (DL 0 0 [])]
+  where
+    cd = canDiag eq as bs lena lenb
+    lena = length as; lenb = length bs
+    searchEndpoint :: Int -> [DL] -> DL
+    searchEndpoint _ [] = error "ses: The search must have a seed node"
+    searchEndpoint d wf = case findEndpoint lena lenb wf of
+      Just p  -> p
+      Nothing -> let wf' = dstep lena lenb cd d wf
+                     _lemmaNonNeg = _minDistanceNonNegative lena lenb wf'
+                  in searchEndpoint (d + 1) wf'
+    -- The abstract refinement @q@ lets 'find' carry the wave
+    -- front element refinement (notably @len (path dl) == d@)
+    -- over to the returned endpoint.
+    findEndpoint :: Int -> Int -> [DL] -> Maybe DL
+    findEndpoint i j = find (endPoint i j)
 
 -- | Takes two lists and returns a list of differences between them. This is
 -- 'getDiffBy' with '==' used as predicate.

--- a/src/Data/Algorithm/Diff.hs
+++ b/src/Data/Algorithm/Diff.hs
@@ -124,9 +124,15 @@ data DL = DL
                      --   'S' steps are stored.
     } deriving (Show, Eq)
 
--- This refinement type alias represents a 'DL' value with a fixed /D-length/,
--- which we call a "D-path location node".
-{-@ type DLN D = { x : DL | len (path x) = D } @-}
+-- Field refinements are implemented with measures, which means they are
+-- available only when a 'DL' value is pattern matched;
+-- This invariant on DLs makes the coordinates non-negativity available
+-- for any value of type 'DL' regardless of whether it has been pattern matched.
+{-@ using (DL) as { dl : DL | poi dl >= 0 && poj dl >= 0 } @-}
+
+-- A "D-path location node" is a 'DL' value within the edit grid bounds
+-- having a fixed /D-length/.
+{-@ type DLN M N D = { x : DL | len (path x) = D && _withinBounds M N x} @-}
 
 {-@ inline _kdiag @-}
 -- | Computes the k-diagonal of a node.
@@ -186,8 +192,14 @@ _wfDiags k (dl:dls) = poi dl - poj dl == k && _wfDiags (k - 2) dls
 
 -- A wave front is a list of 'DL' nodes, all at the same edit distance @D@,
 -- with k-diagonals @D@, @D−2@, …, @-D+2@, @-D@.
-{-@ type WaveFront D = {xs : [DLN D] | _wfDiags D xs} @-}
+-- Wave fronts establish a connection with the Myers algorithm:
+-- @D@ corresponds to the algorithm's current iteration step and the resulting
+-- 'ses' length. In Myers the diagonal arrangement is used to optimize space;
+-- within 'dstep' it allows us to ensure 'furthestReaching' always compares
+-- nodes on the same diagonals.
+{-@ type WaveFront M N D = {xs : [DLN M N D] | _wfDiags (_kdiag (head xs)) xs} @-}
 
+{-@ reflect furthestReaching @-}
 -- | Select the furthest-reaching candidate of two 'DL' nodes competing for the
 -- same k-diagonal, as required by the Myers algorithm.
 --
@@ -202,9 +214,11 @@ _wfDiags k (dl:dls) = poi dl - poj dl == k && _wfDiags (k - 2) dls
 -- and both argument nodes are within the same wave front,
 --
 -- > length (path x) == length (path y)
-{-@ furthestReaching ::  x : DL
-                     -> {y : DL | _kdiag x = _kdiag y}
-                     -> {v : DL | v = x || v = y} @-}
+{-@ furthestReaching
+      ::  x : DL
+      -> {y : DL | _kdiag x = _kdiag y && len (path x) = len (path y)}
+      -> DL
+  @-}
 furthestReaching :: DL -> DL -> DL
 furthestReaching x y
   | poi x >= poi y = x
@@ -219,6 +233,106 @@ furthestReaching x y
 {-@ reflect _manhattanDistance @-}
 _manhattanDistance :: Int -> Int -> DL -> Int
 _manhattanDistance lena lenb dl  = lena - (poi dl) + lenb - (poj dl)
+
+{-@ reflect _wfDistanceToGoal @-}
+-- | The smallest manhattan distance from a wave front node to the goal @(lena, lenb)@.
+-- The empty wave front yields @lena + lenb + 2@, a sentinel strictly greater
+-- than any in-bounds node's distance, acting as the identity for the minimum.
+_wfDistanceToGoal :: Int -> Int -> [DL] -> Int
+_wfDistanceToGoal lena lenb [] = lena + lenb + 2
+_wfDistanceToGoal lena lenb (dl:dls) =
+  -- We avoid using 'min' here so that LH can unfold this definition.
+  if _manhattanDistance lena lenb dl < _wfDistanceToGoal lena lenb dls
+  then _manhattanDistance lena lenb dl
+  else _wfDistanceToGoal lena lenb dls
+
+-- | A lemma that expresses a lower bound of the wavefront distance in terms
+-- of the diagonal of the first node: @lena - lenb - k@
+--
+-- We assume all the nodes to be within the grid.
+--
+-- @lena - lenb@ is the diagonal of the goal. Informally, the
+-- shortest way from a node must necessarily visit all the intermediate
+-- diagonals. The minimum amount of diagonals to visit is given by the
+-- difference between the diagonal indices of the goal and the first element.
+--
+-- We can prove it manually like so:
+--
+-- For every node @dl = DL i j p@ we can prove
+-- @H(dl) = _manhattanDistance lena lenb dl >= lena - lenb - (i - j)@
+--
+-- @
+--   _manhattanDistance lena lenb dl
+-- =
+--   lena - (poi dl) + lenb - (poj dl)
+-- =
+--   lena - i + lenb - j
+-- =
+--   lena - lenb - (i - j) + 2 * (lenb - j)
+-- >=
+--   lena - lenb - (i - j)
+-- @
+--
+-- Since @H(dl)@ holds for every node in the wave front, it follows
+-- that the wave front distance is at least as large as the smallest of
+-- these bounds, which is @lena - lenb - k@ for the largest @k = i0 - j0@,
+-- which is the diagonal of the first node.
+--
+-- QED
+-- @
+{-@ _wfDistanceLowerBoundK
+      :: lena : Nat -> lenb : Nat -> {k : Int | lenb + k + 2 >= 0}
+      -> xs : {v : [{dl : DL | _withinBounds lena lenb dl}] | _wfDiags k v}
+      -> {_wfDistanceToGoal lena lenb xs >= lena - lenb - k}
+      / [len xs] @-}
+_wfDistanceLowerBoundK :: Int -> Int -> Int -> [DL] -> ()
+_wfDistanceLowerBoundK _    _    _ []      = ()
+_wfDistanceLowerBoundK lena lenb k (_:dls) = _wfDistanceLowerBoundK lena lenb (k - 2) dls
+
+-- | If a wave front's node (@prev@) is on the bottom boundary, then the following
+-- nodes lie farther from the goal. Intuitively, the reason is that the following
+-- nodes children would need more steps to cross @prev@'s diagonal to reach the goal.
+-- This lemma allows LH to reason about the case where nodes are discarded
+-- after a bottom-boundary node within 'dstep'.
+{-@
+_wfDistanceLowerBound
+      :: lena : Nat -> lenb : Nat -> {prev : DL | _withinBounds lena lenb prev}
+      -> xs : {v : [{dl : DL | _withinBounds lena lenb dl}] | _wfDiags (_kdiag prev - 2) v}
+      -> { poj prev >= lenb =>  _wfDistanceToGoal lena lenb xs > _manhattanDistance lena lenb prev}
+ @-}
+_wfDistanceLowerBound :: Int -> Int -> DL -> [DL] -> ()
+_wfDistanceLowerBound lena lenb prev [] = ()
+_wfDistanceLowerBound lena lenb prev xs@(_:_) = ()
+  where
+    _lemma = _wfDistanceLowerBoundK lena lenb (_kdiag prev - 2) xs
+
+
+-- | The termination metric is non-negative: every in-bounds node has a
+-- non-negative manhattan distance to the goal, and the empty wave front
+-- yields the positive sentinel. Needed because the @Nat@ result refinement
+-- of the reflected '_wfDistanceToGoal' is not instantiated at logic-level
+-- applications, while termination metrics must be provably non-negative.
+{-@ _minDistanceNonNegative
+      :: lena : Nat -> lenb : Nat
+      -> xs : [{dl : DL | _withinBounds lena lenb dl}]
+      -> {_wfDistanceToGoal lena lenb xs >= 0}
+      / [len xs] @-}
+_minDistanceNonNegative :: Int -> Int -> [DL] -> ()
+_minDistanceNonNegative _    _    []       = ()
+_minDistanceNonNegative lena lenb (_:dls) = _minDistanceNonNegative lena lenb dls
+
+{-@ inline _reducesDistanceToGoal @-}
+_reducesDistanceToGoal :: Int -> Int -> [DL] -> [DL] -> Bool
+_reducesDistanceToGoal lena lenb wf1 wf2 = _wfDistanceToGoal lena lenb wf2 < _wfDistanceToGoal lena lenb wf1
+
+{-@ inline _withinBounds @-}
+{-@ _withinBounds :: lena : Nat -> lenb : Nat -> dl : DL -> {v:Bool | v <=> (poi dl <= lena && poj dl <= lenb) } @-}
+_withinBounds :: Int -> Int -> DL -> Bool
+_withinBounds lena lenb dl = poi dl <= lena && poj dl <= lenb
+
+{-@ inline endPoint @-}
+endPoint :: Int -> Int -> DL -> Bool
+endPoint lena lenb dl = poi dl == lena && poj dl == lenb
 
 -- This refinement type alias allows LiquidHaskell to reason about the function
 -- parameter of 'addsnake' that establishes whether coordinates are within bounds.
@@ -241,7 +355,6 @@ canDiag eq as bs lena lenb = \ i j ->
      arAs = listArray (0,lena - 1) as
      arBs = listArray (0,lenb - 1) bs
 
-{-@ ignore dstep @-}
 -- | Perform one breadth-first search expansion step, advancing every wave front
 -- 'DL' node by one 'DI' edit (one non-diagonal edge) and then following
 -- any available snake.
@@ -270,8 +383,10 @@ dstep
   -> lenb : Nat
   -> DiagPred lena lenb
   -> d : Nat
-  -> {nodes : WaveFront d | len nodes > 0}
-  -> {v : WaveFront (d + 1) | len v = len nodes + 1}
+  -> {nodes : WaveFront lena lenb d | len nodes > 0
+                                   && not (endPoint lena lenb (head nodes))
+                                   && _wfDistanceToGoal lena lenb nodes > 0}
+  -> {v : WaveFront lena lenb (d + 1) | len v > 0 && _reducesDistanceToGoal lena lenb nodes v}
 @-}
 dstep
   :: Int                  -- ^ First input's length phantom parameter for termination check.
@@ -287,22 +402,41 @@ dstep lena lenb _ _d [] = error "dstep: Cannot perform expansion on an empty lis
 -- to avoid constructing out-of-bound nodes and discarding other non-competing nodes.
 dstep lena lenb cd _ (dl:dls) =
   if poi dl >= lena then stepAndMerge dl dls
-  else addsnake lena lenb cd (hStep dl) : stepAndMerge dl dls
+  else
+    (addsnake lena lenb cd (hStep dl) : stepAndMerge dl dls)
+      -- If @dl@ lies on the bottom boundary, @stepAndMerge dl dls@ discards
+      -- all of @dls@; the lemma shows the discarded nodes are farther from
+      -- the goal than @dl@'s horizontal child.
+      `const` _wfDistanceLowerBound lena lenb dl dls
   where
-    {-@ hStep :: x : DLN _d -> {v : DLN (_d + 1) | _kdiag v = _kdiag x + 1} @-}
+    {-@ hStep
+          :: x : DLN lena lenb _d
+          -> {v : DL | len (path v) = _d + 1 && poi v = poi x + 1 && poj v = poj x} @-}
     hStep node = node {poi = poi node + 1, path = F : path node}
-    {-@ vStep :: x : DLN _d -> {v : DLN (_d + 1) | _kdiag v = _kdiag x - 1} @-}
+    {-@ vStep
+          :: x : DLN lena lenb _d
+          -> {v : DL | len (path v) = _d + 1 && poi v = poi x && poj v = poj x + 1} @-}
     vStep node = node {poj = poj node + 1, path = S : path node}
     -- Merge vertical step of previous node with horizontal step of next node,
     -- selecting the furthest-reaching candidate for each shared k-diagonal,
     -- and extend it along matching elements.
-     {-@ stepAndMerge :: prev : DLN _d
-                     -> {rest : [DLN _d] | _wfDiags (_kdiag prev - 2) rest}
-                     -> {v : [DLN (_d+1)] | _wfDiags (_kdiag prev - 1) v && len v = len rest + 1}
-                     / [len rest] @-}
+    {-@ stepAndMerge
+          :: prev : DLN lena lenb _d
+          -> nodes : {xs : [DLN lena lenb _d] | _wfDiags (_kdiag prev - 2) xs
+                                             && _wfDistanceToGoal lena lenb xs > 0}
+          -> {v : [DLN lena lenb (_d + 1)]
+             |  _wfDiags (_kdiag prev - 1) v
+             && (poj prev < lenb <=> len v > 0)
+             && (len v > 0 => _kdiag (head v) == _kdiag prev - 1)
+             && (len v > 0 =>
+                   _wfDistanceToGoal lena lenb v < _manhattanDistance lena lenb prev)
+             && (len v > 0 =>
+                   _wfDistanceToGoal lena lenb v < _wfDistanceToGoal lena lenb nodes)
+             }
+          / [len nodes] @-}
     stepAndMerge prev nodes =
       -- When a node lies in the bottom boundary no subsequent node can reach
-      -- the goal faster.
+      -- the goal faster. See lemma '_wfDistanceLowerBound'.
       if poj prev >= lenb then []
       else case nodes of
         [] -> [addsnake lena lenb cd $ vStep prev]
@@ -314,7 +448,12 @@ dstep lena lenb cd _ (dl:dls) =
             -- the '_wfDiags' invariant at a negligible performance penalty.
             -- See [NOTE: diagonal-invariant]
             if poi next >= lena then vStep prev : stepAndMerge next rest
-            else addsnake lena lenb cd (furthestReaching (vStep prev) (hStep next)) : stepAndMerge next rest
+            else
+              (addsnake lena lenb cd (furthestReaching (vStep prev) (hStep next)) : stepAndMerge next rest)
+                -- If @next@ lies on the bottom boundary, the recursive call
+                -- discards all of @rest@; the lemma shows the discarded nodes
+                -- are farther from the goal than the merged child.
+                `const` _wfDistanceLowerBound lena lenb next rest
 
 -- | Follow a /snake/ from the current position of a 'DL' node.
 --
@@ -328,9 +467,12 @@ dstep lena lenb cd _ (dl:dls) =
 addsnake :: lena : Nat
          -> lenb : Nat
          -> DiagPred lena lenb
-         -> dl : DL
+         -> {dl : DL | _withinBounds lena lenb dl}
          -> {v : DL | path v == path dl
-                   && _kdiag v = _kdiag dl}
+                   && _kdiag v = _kdiag dl
+                   && _withinBounds lena lenb v
+                   && poi v >= poi dl
+                   && poj v >= poj dl}
          / [_manhattanDistance lena lenb dl]
 @-}
 addsnake :: Int                  -- ^ First input's length phantom parameter for termination check.


### PR DESCRIPTION
This PR adds an static check for the `ses` (_smallest edit script_) function termination by defining a wave front's distance to the _endpoint_ as decreasing metric. This function is the implementation's entry point to the Myers diff algorithm, whose original specification waives the need for a termination proof by bounding the algorithm's outer loop by the known worst case edit script length (i.e. the sum of both input's lengths). The implicit termination proof contained in this check provides a compeling argument for the correctness of the implementation by stablishing a link with its original specification.

The check depends on:

- The refactoring of `dstep` (https://github.com/seereason/Diff/pull/37/commits/2825ba19f4c4838573d31cd87978740adb77e155) and `ses` (https://github.com/seereason/Diff/pull/37/commits/572638c63334416281ef814e0e8244e3e358129a ) functions. The former resulting in a 4x performance improvement that required a new benchmark comparing inputs with a bigger size difference (https://github.com/seereason/Diff/pull/37/commits/607c8d38138f153a8c4afca2761c914fcbc21caa) to be noticed.
-  The addition of phantom (i.e. unused in source code) parameters to `dstep` and `addsnake` (https://github.com/seereason/Diff/pull/37/commits/8eba64a429538204132c91d57bd0bce3851f8941) to _thread_ a notion of the edit grid within the call stack
- And the inclusion of supplementary functions that are only relevant to the Liquid Haskell specifications and have no impact in the implementation whatsoever.

## Refactorings

The "iterate, flatten and find" steps of `ses` are merged in a single "search" step. Formerly, the search for the _endpoint_ was done using `dropWhile (\dl -> poi dl /= lena || poj dl /= lenb)` on a single infinite stream containing all nodes, from succesive iterations of the wave front, in order. Now, the `seach :: Int -> [DL] -> [DI]` does the same thing, inspecting one wave front iteration at a time, allowing Liquid Haskell to reason about the incremental reach of the wave front to the goal. Benchmarks (`cabal bench`) shows a negligeble performance gain on this change alone when tested on a local branch. This is still the case after the `dstep` optimization; before and after benchmark results are shown below.

The `dstep` optimization consist (informally) of narrowing the wave front to in-bound nodes only: checks are placed to drop non-competing and out-of-bound nodes. The performance gain on the existing benchmark is barely noticeable. However, the new benchmark comparing inputs differing noticeably in size shows the gain to be in the order of 4x for this case. Incidentally, this addresses #1 robustly for all disparities between input sizes, which the additional equations to `getDiffBy` added in #28 solved for the specific case of an input of size 0; these equations are removed to avoid the unnecessary complexity of this ad hoc case.
This refactoring is instrumental to prove `dstep` reduces `wfDistanceToGoal` (https://github.com/seereason/Diff/pull/37/commits/6590d8ed1923c7cc159b9aaac30263ae9b838b33), providing guarantee that the `manhattanDistance` is non-negative on all wave front nodes. Also, the previously local `hStep` and `vStep` functions where moved to the top level in to `reflect` them (https://github.com/seereason/Diff/pull/37/commits/bc324f5b3c27296b20fe83c7615960477946f35b), making their unfoldings available in the refinement logic, in order to reduce the specification load: otherwise, they incur in substantive specifications of their own (as found before this change in https://github.com/seereason/Diff/pull/37/commits/6590d8ed1923c7cc159b9aaac30263ae9b838b33). For details on how this refactoring is related to the _wave front specification_ see `[NOTE: diagonal-invariant]`.

### Benchmarks

Before `dstep` refactoring (on https://github.com/seereason/Diff/pull/37/commits/607c8d38138f153a8c4afca2761c914fcbc21caa)

```
Benchmark simple: RUNNING...
benchmarking diff bool lists/1000 bools
time                 5.747 ms   (5.610 ms .. 5.851 ms)
                     0.998 R�   (0.998 R� .. 0.999 R�)
mean                 5.534 ms   (5.503 ms .. 5.581 ms)
std dev              122.2  s   (89.75  s .. 175.3  s)

benchmarking diff bool lists/1000/500 bools
time                 7.767 ms   (7.691 ms .. 7.842 ms)
                     1.000 R�   (0.999 R� .. 1.000 R�)
mean                 7.736 ms   (7.698 ms .. 7.777 ms)
std dev              119.6  s   (96.57  s .. 148.0  s)

Benchmark simple: FINISH
```

After `dstep` refactoring, but before `ses` refactoring (on https://github.com/seereason/Diff/pull/37/commits/6590d8ed1923c7cc159b9aaac30263ae9b838b33)

```
Benchmark simple: RUNNING...
benchmarking diff bool lists/1000 bools
time                 5.199 ms   (5.158 ms .. 5.263 ms)
                     0.999 R�   (0.999 R� .. 1.000 R�)
mean                 5.179 ms   (5.156 ms .. 5.202 ms)
std dev              68.38  s   (56.26  s .. 86.47  s)

benchmarking diff bool lists/1000/500 bools
time                 1.897 ms   (1.886 ms .. 1.912 ms)
                     1.000 R�   (0.999 R� .. 1.000 R�)
mean                 1.893 ms   (1.887 ms .. 1.899 ms)
std dev              21.91  s   (17.44  s .. 26.36  s)

Benchmark simple: FINISH
```

After both refactorings (on https://github.com/seereason/Diff/pull/37/commits/52f18d4ae2a6ab8c5daee5b28fe4b1e4d57187aa): 

```
Benchmark simple: RUNNING...
benchmarking diff bool lists/1000 bools
time                 4.604 ms   (4.570 ms .. 4.629 ms)
                     1.000 R�   (1.000 R� .. 1.000 R�)
mean                 4.633 ms   (4.617 ms .. 4.651 ms)
std dev              53.36  s   (44.97  s .. 65.39  s)

benchmarking diff bool lists/1000/500 bools
time                 1.619 ms   (1.609 ms .. 1.630 ms)
                     1.000 R�   (1.000 R� .. 1.000 R�)
mean                 1.629 ms   (1.625 ms .. 1.634 ms)
std dev              16.82  s   (14.07  s .. 20.30  s)

Benchmark simple: FINISH
```

## Phantom parameters and Liquid Haskell supplementary functions.

The new phantom parameters in `dstep` and `addsnake` carrying both input lengths are used to pass these values to the supplementary functions defined under the `Proving the Algorithm's Termination in LiquidHaskell` code section at the bottom of `Diff.hs`. 

LiquidHaskell specific machinery leading to the definition of the `WaveFront` refinement type alias (introduced in #32) is moved to the new code section `LiquidHaskell Wave Front Specification`, also near the bottom of the file. The `DLN` alias is modified to take parameters for the input lengths, and a local invariant for the `DL` type is added in a `using` annotation to make the positivity of its coordinates available in contexts where their values where not pattern matched.