### PR TITLE
Fix division by zero error in `prop_ppDiffR`

### DIFF
--- a/test/Test.hs
+++ b/test/Test.hs
@@ -164,7 +164,8 @@ prop_ppDiffR (DiffInput le ri) =
     let haskDiff=ppDiff $ getGroupedDiff le ri
         utilDiff= unsafePerformIO (runDiff (unlines le) (unlines ri))
     in  cover 90 (haskDiff == utilDiff) "exact match" $
-                classify (haskDiff == utilDiff) "exact match"
+                classify (haskDiff == utilDiff) "exact match" $
+                    not (null utilDiff) ==>
                         (div ((length (lines haskDiff))*100) (length (lines utilDiff)) < 110) -- less than 10% bigger
     where
       runDiff left right =

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -165,8 +165,10 @@ prop_ppDiffR (DiffInput le ri) =
         utilDiff= unsafePerformIO (runDiff (unlines le) (unlines ri))
     in  cover 90 (haskDiff == utilDiff) "exact match" $
                 classify (haskDiff == utilDiff) "exact match" $
-                    not (null utilDiff) ==>
-                        (div ((length (lines haskDiff))*100) (length (lines utilDiff)) < 110) -- less than 10% bigger
+                    div
+                      (length (lines haskDiff)*100)
+                      (max 1 $ length $ lines utilDiff)
+                    < 110 -- less than 10% bigger
     where
       runDiff left right =
           do leftFile <- writeTemp left


### PR DESCRIPTION
The `prop_ppDiffR` has a division by zero whenever the random generated inputs are equal, resulting in a (false) test suite failure. This happens with

```shell
cabal test diff-tests --test-options='-t "compare random with diff" --test-seed=5636946790713128664'
```

This PR fixes this by avoiding this edge case.
