### PR TITLE
Include LiquidHaskell check in distribution and add acknowledgements

### DIFF
--- a/Diff-liquidhaskell/Diff-liquidhaskell.cabal
+++ b/Diff-liquidhaskell/Diff-liquidhaskell.cabal
@@ -1,20 +1,19 @@
 cabal-version: 2.4
 name:          Diff-liquidhaskell
 version:       0.1.0.0
-synopsis:      Liquid Haskell static checks for the Diff package
+synopsis:      LiquidHaskell static checks for the Diff package
 description:
-  Provides a test suite whose build executes Diff's Liquid Haskell refinement type
+  Provides a test suite whose build executes Diff's LiquidHaskell refinement type
   annotation checks.
   Exists as a separate package to break the cyclic dependency:
   Diff -> liquidhaskell -> liquidhaskell-boot -> Diff.
-license:       BSD-3-Clause
 build-type:    Simple
 
 tested-with:   GHC == 9.14.1
 
 library
   default-language: Haskell2010
-  -- Re-use the main Diff source tree so Liquid Haskell checks the real code.
+  -- Re-use the main Diff source tree so LiquidHaskell checks the real code.
   hs-source-dirs:   ../src
   -- No modules are exposed because this package is intended
   -- for checking the build only.

--- a/Diff.cabal
+++ b/Diff.cabal
@@ -1,4 +1,4 @@
-Cabal-Version:       1.18
+Cabal-Version:       3.14
 name:                Diff
 version:             1.0.2
 synopsis:            Diff algorithm in pure Haskell
@@ -8,12 +8,14 @@ description:         Implementation of the standard diff algorithm in Haskell.
  Space complexity is O(D^2).  Includes utilities for pretty printing.
 category:            Algorithms
 homepage:            https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.4.6927
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Sterling Clover
 maintainer:          David Fox <dsf@seereason.com>
-Build-Type:          Simple
-extra-doc-files:     README.md
+build-Type:          Simple
+extra-doc-files:     README.md, CHANGELOG.md
+extra-files:         ./Diff-liquidhaskell/Diff-liquidhaskell.cabal
+bug-reports:         https://github.com/seereason/Diff/issues
 
 tested-with:
   GHC == 9.14.1
@@ -28,8 +30,6 @@ tested-with:
   GHC == 8.8.4
   GHC == 8.6.5
   GHC == 8.4.4
-
-extra-doc-files:     CHANGELOG.md
 
 library
   default-language: Haskell2010

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Benchmark with
 cabal bench
 ```
 
-### Checking Diff with Liquid Haskell
+### Checking Diff with LiquidHaskell
 
-The Diff source code can we checked with [Liquid Haskell](https://ucsd-progsys.github.io/liquidhaskell/).
+The Diff source code can we checked with [LiquidHaskell](https://ucsd-progsys.github.io/liquidhaskell/).
 
-Liquid Haskell requires `ghc` version 9.14.1, and an SMT solver. We have tested
+LiquidHaskell requires `ghc` version 9.14.1, and an SMT solver. We have tested
 the checks with the [Z3](https://github.com/Z3Prover/z3) SMT solver (versions 4.16,
 and 4.15.1).
 
@@ -44,4 +44,10 @@ flowchart LR
     Diff --> liquidhaskell --> liquidhaskell-boot --> Diff
 ```
 
-Contributions that update the Liquid Haskell checks are appreciated but not required at this point.
+Contributions that update the LiquidHaskell checks are appreciated but not required at this point.
+
+### Acknowledgments
+
+The LiquidHaskell static checks were designed and implemented with the support of
+[Tweag](https://www.tweag.io/), a part of [Modus Create](https://www.moduscreate.com/).
+Learn more in this [blog post](https://www.tweag.io/blog/2026-06-11-diff-package-static-checks/).

--- a/src/Data/Algorithm/Diff/Refinement.hs
+++ b/src/Data/Algorithm/Diff/Refinement.hs
@@ -1,5 +1,5 @@
 -- | Refinement type aliases for 'PolyDiff', related predicates and (lifted) utility functions.
--- The contents of this module are intended for use in Liquid Haskell specifications;
+-- The contents of this module are intended for use in LiquidHaskell specifications;
 -- importing this module can result in unused import warnings in GHC,
 -- which can be suppressed with @-Wno-unused-imports@.
 module Data.Algorithm.Diff.Refinement where


### PR DESCRIPTION
 `Diff.cabal` is updated to include `Diff-liquidhaskell.cabal` in the source distribution using the `extra-files` field (which seems to be the appropriate one for this case). This provides users getting the code from the hackage tarball a means to run the static checks. The new field required bumping cabal version to `3.14`, which in turn required the license field to be updated to a SPDX compliant license (`BSD-3-Clause`). A url pointing to this package issue tracker was added as well.
 
The licese field is removed from `Diff-liquidhaskell.cabal`: being an artificial package to avoid a cyclic dependency, it seems unnecessary to have this field.
 
Tweag's support for writing the LiquidHaskell static checks is aknowledged in the `README.md`, and a link to a blog post providing insight into the static checks development is included alongside it.

Intances of "Liquid Haskell" are changed to "LiquidHaskell" (without space) to have a single naming convention across the repository.