### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.0
+
+  - Remove `groupBy'` from `Data.Algorithm.DiffContext` exports (#26).
+    Use `Data.List.GroupBy.groupBy` from `groupBy` package instead.
+  - Optimize `Data.Algorithm.Diff` functions (#25, #30, #37).
+    ~2.4x and ~8.5x `getDiff` improvement on benchmarks.
+
 # 1.0.2
 
   - Output correct format when an input file is empty, e.g. `@@ --0,0 +1,3 @@`.

--- a/Diff.cabal
+++ b/Diff.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:       3.14
 name:                Diff
-version:             1.0.2
+version:             2.0.0
 synopsis:            Diff algorithm in pure Haskell
 description:         Implementation of the standard diff algorithm in Haskell.
  .


### PR DESCRIPTION
This version benefits from relevant performance optimizations (see #25, #30 and #37, leading to a ~2.4x and ~8.5x `getDiff` improvement on benchmarks) and removes `groupBy'` from the API (see #26). The latter calls for a major version bump, hence `1.0.2` -> `2.0.0`.